### PR TITLE
fix(status): Implement `handle_info/2` callback in mria_status

### DIFF
--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -276,11 +276,7 @@ handle_call(_, State) ->
     {ok, {error, unknown_call}, State, hibernate}.
 
 handle_info(_Info, State) ->
-    ?tp( mria_status_handle_info
-       , #{ msg => _Info
-          }
-       ),
-    {ok, State}.
+    ?tp(mria_status_handle_info, #{msg => _Info}), {ok, State}.
 
 handle_event(Event, State = #s{ref = Ref, subscriber = Sub}) ->
     Sub ! {Ref, Event},

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -36,7 +36,7 @@
         ]).
 
 %% gen_event callbacks:
--export([init/1, handle_call/2, handle_event/2]).
+-export([init/1, handle_call/2, handle_event/2, handle_info/2]).
 
 -define(SERVER, ?MODULE).
 
@@ -274,6 +274,13 @@ init([Ref, Subscriber]) ->
 
 handle_call(_, State) ->
     {ok, {error, unknown_call}, State, hibernate}.
+
+handle_info(_Info, State) ->
+    ?tp( mria_status_handle_info
+       , #{ msg => _Info
+          }
+       ),
+    {ok, State}.
 
 handle_event(Event, State = #s{ref = Ref, subscriber = Sub}) ->
     Sub ! {Ref, Event},

--- a/test/concuerror_tests.erl
+++ b/test/concuerror_tests.erl
@@ -175,16 +175,15 @@ mria_status_handle_info_test() ->
                HandlerPid1 = CreateHandler(),
                HandlerPid0 ! die,
                {HandlerPid0, HandlerPid1}
-           end
-          , fun({HandlerPid0, HandlerPid1}, Trace) ->
+           end,
+           fun({HandlerPid0, HandlerPid1}, Trace) ->
                     ?assertMatch(
                        [#{msg := {'EXIT', _, _}}]
                       , ?of_kind(mria_status_handle_info, Trace)),
                     ?assert(is_process_alive(ServerPid)),
                     ?assert(is_process_alive(HandlerPid1)),
                     ?assert(not is_process_alive(HandlerPid0))
-            end
-          )
+            end)
     after
         cleanup(ServerPid)
     end.


### PR DESCRIPTION
Fixes #17.

On some conditions, the `mria_status` `gen_event` server may receive a
`{'EXIT', From, Reason}` message from some linked process that has
called `mria_status`. Since `mria_status` does not currently implement
the `handle_info/2` callback, it crashes and logs a message like this:

```
** Undefined handle_info in mria_status
** Unhandled message: {'EXIT',<0.492.0>,shutdown}
```

By implementing the missing callback and just ignoring the unexpected
message, we avoid spamming the logs with messages like this.