### PR TITLE
fix(spec): remove impossible `{timeout, [_]}` case from typespec

### DIFF
--- a/src/mria.erl
+++ b/src/mria.erl
@@ -241,7 +241,7 @@ create_table(Name, TabDef) ->
             end
     end.
 
--spec wait_for_tables([table()]) -> ok | {error, _Reason} | {timeout, [table()]}.
+-spec wait_for_tables([table()]) -> ok | {error, _Reason}.
 wait_for_tables(Tables) ->
     case mria_mnesia:wait_for_tables(Tables) of
         ok ->

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -253,7 +253,7 @@ copy_table(Name, Storage) ->
             ?LOG(warning, "Ignoring illegal attempt to create a table copy ~p on replicant node ~p", [Name, node()])
     end.
 
--spec wait_for_tables([mria:table()]) -> ok | {error, _Reason} | {timeout, [mria:table()]}.
+-spec wait_for_tables([mria:table()]) -> ok | {error, _Reason}.
 wait_for_tables(Tables) ->
     ?tp(mria_wait_for_tables, #{tables => Tables}),
     case mnesia:wait_for_tables(Tables, 30000) of


### PR DESCRIPTION
Fixes #21.

The functions `mria{,_mnesia}:wait_for_tables/1` declare in their
typespecs that they may return `{timeout, [table()]}`. But
`mria_mnesia:wait_for_tables/1` will enter a (possibly infinite) loop
when `mnesia:wait_for_tables` returns such tuple, effectively ruling
out this return value.