### PR TITLE
Mulitple tcp connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ app.config: $(CUTTLEFISH_SCRIPT)
 
 CONCUERROR := $(BUILD_DIR)/Concuerror/bin/concuerror
 CONCUERROR_RUN := $(CONCUERROR) \
-	--treat_as_normal shutdown --treat_as_normal normal \
+	--treat_as_normal shutdown --treat_as_normal normal --treat_as_normal intentional \
 	-x code -x code_server -x error_handler \
 	-pa $(BUILD_DIR)/concuerror+test/lib/snabbkaffe/ebin \
 	-pa $(BUILD_DIR)/concuerror+test/lib/mria/ebin
@@ -91,6 +91,7 @@ concuerror_test: $(CONCUERROR)
 	$(call concuerror,notify_different_tags_test)
 	$(call concuerror,get_core_node_test)
 	$(call concuerror,dirty_bootstrap_test)
+	$(call concuerror,mria_status_handle_info_test)
 
 $(CONCUERROR):
 	mkdir -p _build/

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.14.1"}}},
-        {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}},
+        {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.6.0"}}},
         {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.1"}}},
         {mnesia_rocksdb, {git, "https://github.com/k32/mnesia_rocksdb", {tag, "0.1.0"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -35,13 +35,21 @@
  ]}.
 
 {profiles,
- [{test,
-   [{plugins, [{coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "github"}}}]},
-    {deps, [{meck, "0.8.13"},
-            {proper, "1.3.0"}
-           ]},
-    {erl_opts, [debug_info]}
-   ]}
+ [ {test,
+    [{plugins, [{coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "github"}}}]},
+     {deps, [{meck, "0.8.13"},
+             {proper, "1.3.0"}
+            ]},
+     {erl_opts, [debug_info]}
+    ]}
+ , {concuerror,
+    [{overrides,
+      [ {add, snabbkaffe,
+         [{erl_opts, [{d, 'CONCUERROR'}]}]}
+      , {add, mria,
+         [{erl_opts, [{d, 'CONCUERROR'}]}]}
+      ]}
+    ]}
  ]}.
 
 {ct_readable, true}.

--- a/src/mria.erl
+++ b/src/mria.erl
@@ -341,7 +341,7 @@ dirty_delete_object(Record) ->
 -spec ro_trans_rpc(mria_rlog:shard(), fun(() -> A)) -> t_result(A).
 ro_trans_rpc(Shard, Fun) ->
     {ok, Core} = mria_status:get_core_node(Shard, 5000),
-    case mria_lib:rpc_call(Core, ?MODULE, ro_transaction, [Shard, Fun]) of
+    case mria_lib:rpc_call({Core, Shard}, ?MODULE, ro_transaction, [Shard, Fun]) of
         {badrpc, Err} ->
             ?tp(error, ro_trans_badrpc,
                 #{ core   => Core

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -20,6 +20,7 @@
 -export([ role/0
         , backend/0
         , rpc_module/0
+        , tlog_push_mode/0
         , strict_mode/0
 
         , load_config/0
@@ -82,6 +83,10 @@ role() ->
 -spec rpc_module() -> gen_rpc | rpc.
 rpc_module() ->
     persistent_term:get(?mria(rlog_rpc_module), gen_rpc).
+
+-spec tlog_push_mode() -> sync | async.
+tlog_push_mode() ->
+    application:get_env(mria, tlog_push_mode, async).
 
 %% Flag that enables additional verification of transactions
 -spec strict_mode() -> boolean().

--- a/src/mria_rlog_agent.erl
+++ b/src/mria_rlog_agent.erl
@@ -147,7 +147,7 @@ handle_mnesia_event({Shard, TXID, Ops}, _ActivityId, D = #d{shard = Shard}) ->
          , seqno       => SeqNo
          }),
     Tx = {self(), SeqNo, TXID, [Ops]},
-    ok = mria_rlog_replica:push_tlog_entry(PushMode, D#d.subscriber, Tx),
+    ok = mria_rlog_replica:push_tlog_entry(PushMode, Shard, D#d.subscriber, Tx),
     {keep_state, D#d{seqno = SeqNo + 1}}.
 
 subscribe_realtime(D) ->

--- a/src/mria_rlog_replica.erl
+++ b/src/mria_rlog_replica.erl
@@ -25,7 +25,7 @@
 -export([init/1, terminate/3, code_change/4, callback_mode/0, handle_event/4]).
 
 %% Internal exports:
--export([do_push_tlog_entry/2, push_tlog_entry/3]).
+-export([do_push_tlog_entry/2, push_tlog_entry/4]).
 
 -include("mria_rlog.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
@@ -141,12 +141,12 @@ terminate(_Reason, _State, #d{}) ->
 %%================================================================================
 
 %% This function is called by the remote core node.
--spec push_tlog_entry(sync | async, mria_lib:subscriber(), mria_lib:tlog_entry()) -> ok.
-push_tlog_entry(async, {Node, Pid}, Batch) ->
-    mria_lib:rpc_cast(Node, ?MODULE, do_push_tlog_entry, [Pid, Batch]),
+-spec push_tlog_entry(sync | async, mria_rlog:shard(), mria_lib:subscriber(), mria_lib:tlog_entry()) -> ok.
+push_tlog_entry(async, Shard, {Node, Pid}, Batch) ->
+    mria_lib:rpc_cast({Node, Shard}, ?MODULE, do_push_tlog_entry, [Pid, Batch]),
     ok;
-push_tlog_entry(sync, {Node, Pid}, Batch) ->
-    mria_lib:rpc_call(Node, ?MODULE, do_push_tlog_entry, [Pid, Batch]).
+push_tlog_entry(sync, Shard, {Node, Pid}, Batch) ->
+    mria_lib:rpc_call({Node, Shard}, ?MODULE, do_push_tlog_entry, [Pid, Batch]).
 
 %%================================================================================
 %% Internal functions

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -277,7 +277,8 @@ handle_call(_, State) ->
     {ok, {error, unknown_call}, State, hibernate}.
 
 handle_info(_Info, State) ->
-    ?tp(mria_status_handle_info, #{msg => _Info}), {ok, State}.
+    ?tp(mria_status_handle_info, #{msg => _Info}),
+    {ok, State}.
 
 handle_event(Event, State = #s{ref = Ref, subscriber = Sub}) ->
     Sub ! {Ref, Event},

--- a/test/concuerror_tests.erl
+++ b/test/concuerror_tests.erl
@@ -19,6 +19,7 @@
 -module(concuerror_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-define(CONCUERROR, true).
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %% Note: the number of interleavings that Concuerror has to explore

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -197,28 +197,33 @@ t_rlog_smoke_test(_) ->
     Env = [ {mria, bootstrapper_chunk_config, #{count_limit => 3}}
           | mria_mnesia_test_util:common_env()
           ],
+    NTrans = 300,
     Cluster = mria_ct:cluster([core, core, replicant], Env),
     CounterKey = counter,
     ?check_trace(
-       #{timetrap => 10000},
+       #{timetrap => NTrans * 10 + 10_000},
        try
            %% Inject some orderings to make sure the replicant
            %% receives transactions in all states.
            %%
            %% 1. Commit some transactions before the replicant start:
-           ?force_ordering(#{?snk_kind := trans_gen_counter_update, value := 5}, #{?snk_kind := state_change, to := disconnected}),
+           ?force_ordering(#{?snk_kind := trans_gen_counter_update, value := 5},
+                           #{?snk_kind := state_change, to := disconnected}),
            %% 2. Make sure the rest of transactions are produced after the agent starts:
-           ?force_ordering(#{?snk_kind := subscribe_realtime_stream}, #{?snk_kind := trans_gen_counter_update, value := 10}),
+           ?force_ordering(#{?snk_kind := subscribe_realtime_stream},
+                           #{?snk_kind := trans_gen_counter_update, value := 10}),
            %% 3. Make sure transactions are sent during TLOG replay: (TODO)
-           ?force_ordering(#{?snk_kind := state_change, to := bootstrap}, #{?snk_kind := trans_gen_counter_update, value := 15}),
+           ?force_ordering(#{?snk_kind := state_change, to := bootstrap},
+                           #{?snk_kind := trans_gen_counter_update, value := 15}),
            %% 4. Make sure some transactions are produced while in normal mode
-           ?force_ordering(#{?snk_kind := state_change, to := normal}, #{?snk_kind := trans_gen_counter_update, value := 25}),
+           ?force_ordering(#{?snk_kind := state_change, to := normal},
+                           #{?snk_kind := trans_gen_counter_update, value := 25}),
 
            Nodes = [N1, N2, N3] = mria_ct:start_cluster(mria_async, Cluster),
            ok = mria_mnesia_test_util:wait_tables([N1, N2]),
            %% Generate some transactions:
            {atomic, _} = rpc:call(N2, mria_transaction_gen, create_data, []),
-           ok = rpc:call(N1, mria_transaction_gen, counter, [CounterKey, 30]),
+           ok = rpc:call(N1, mria_transaction_gen, counter, [CounterKey, NTrans]),
            mria_mnesia_test_util:stabilize(1000),
            %% Check status:
            [?assertMatch(#{}, rpc:call(N, mria, info, [])) || N <- Nodes],
@@ -238,6 +243,7 @@ t_rlog_smoke_test(_) ->
            ok
        end,
        fun([N1, N2, N3], Trace) ->
+               ?assert(mria_rlog_props:no_tlog_gaps(Trace)),
                %% Ensure that the nodes assumed designated roles:
                ?projection_complete(node, ?of_kind(rlog_server_start, Trace), [N1, N2]),
                ?projection_complete(node, ?of_kind(rlog_replica_start, Trace), [N3]),

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -201,7 +201,7 @@ t_rlog_smoke_test(_) ->
     Cluster = mria_ct:cluster([core, core, replicant], Env),
     CounterKey = counter,
     ?check_trace(
-       #{timetrap => NTrans * 10 + 10_000},
+       #{timetrap => NTrans * 10 + 10000},
        try
            %% Inject some orderings to make sure the replicant
            %% receives transactions in all states.

--- a/test/mria_mnesia_test_util.erl
+++ b/test/mria_mnesia_test_util.erl
@@ -69,4 +69,5 @@ common_env() ->
     [ {mria, db_backend, rlog}
     , {mria, rlog_startup_shards, [test_shard]}
     , {mria, strict_mode, true}
+    , {mria, rpc_module, gen_rpc}
     ].

--- a/test/mria_rlog_props.erl
+++ b/test/mria_rlog_props.erl
@@ -20,6 +20,7 @@
         , replicant_bootstrap_stages/2
         , all_batches_received/1
         , counter_import_check/3
+        , no_tlog_gaps/1
         ]).
 
 -include_lib("snabbkaffe/include/test_macros.hrl").
@@ -87,6 +88,11 @@ check_transaction_replay_sequence([]) ->
     true;
 check_transaction_replay_sequence([First|Rest]) ->
     check_transaction_replay_sequence(First, First, Rest).
+
+%% Check that there are no gaps in the transaction log
+no_tlog_gaps(Trace) ->
+    ?assertEqual([], ?of_kind(gap_in_the_tlog, Trace)),
+    true.
 
 %%================================================================================
 %% Internal functions


### PR DESCRIPTION
Performance optimizations:
1. Forwarding of the TLOGs to the replicant nodes is made asynchronous (call -> cast)
2. Use a different TCP connection for each shard

Also some test fixes.