### PR TITLE
fix(activity): Remove nested transactions

### DIFF
--- a/src/mria.erl
+++ b/src/mria.erl
@@ -303,7 +303,7 @@ transaction(Shard, Fun, Args) ->
 
 -spec transaction(mria_rlog:shard(), fun(() -> A)) -> t_result(A).
 transaction(Shard, Fun) ->
-    transaction(Shard, fun erlang:apply/2, [Fun, []]).
+    transaction(Shard, Fun, []).
 
 -spec clear_table(mria:table()) -> t_result(ok).
 clear_table(Table) ->

--- a/src/mria_activity.erl
+++ b/src/mria_activity.erl
@@ -33,15 +33,15 @@
 
 -spec transaction(fun(() -> A)) -> A.
 transaction(Fun) ->
-    unwrap_mnesia_ret(mnesia:transaction(Fun)).
+    Fun().
 
 -spec transaction(fun((...) -> A), list()) -> A.
 transaction(Fun, Args) ->
-    unwrap_mnesia_ret(mnesia:transaction(Fun, Args)).
+    apply(Fun, Args).
 
 -spec ro_transaction(fun(() -> A)) -> A.
 ro_transaction(Fun) ->
-    Ret = unwrap_mnesia_ret(mnesia:transaction(Fun)),
+    Ret = Fun(),
     assert_ro(),
     Ret.
 
@@ -59,11 +59,6 @@ clear_table(Tab) ->
 %%================================================================================
 %% Internal functions
 %%================================================================================
-
-unwrap_mnesia_ret({atomic, Ret}) ->
-    Ret;
-unwrap_mnesia_ret({aborted, Ret}) ->
-    mnesia:abort(Ret).
 
 assert_ro() ->
     case mria_config:strict_mode() of


### PR DESCRIPTION
There is very little reason to use nested transactions to capture TLOGs. Removing them will make code cleaner and possible slightly faster.