### PR TITLE
feat(core_node_callback): add callback to enumerate core nodes

### DIFF
--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -23,6 +23,7 @@
 %% API
 -export([ start_link/0
         , probe/2
+        , core_nodes/0
         ]).
 
 %% gen_server callbacks
@@ -48,10 +49,12 @@
 
 -record(s,
         { core_protocol_versions :: core_protocol_versions()
+        , core_nodes :: [node()]
         }).
 
 -define(update, update).
 -define(SERVER, ?MODULE).
+-define(CORE_DISCOVERY_TIMEOUT, 30000).
 
 %%================================================================================
 %% API
@@ -64,6 +67,10 @@ start_link() ->
 probe(Node, Shard) ->
     gen_server:call(?SERVER, {probe, Node, Shard}).
 
+-spec core_nodes() -> [node()].
+core_nodes() ->
+    gen_server:call(?SERVER, core_nodes, ?CORE_DISCOVERY_TIMEOUT).
+
 %%================================================================================
 %% gen_server callbacks
 %%================================================================================
@@ -72,10 +79,13 @@ init(_) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => [mria, rlog, lb]}),
     init_timer(),
-    {ok, #s{core_protocol_versions = #{}}}.
+    State = #s{ core_protocol_versions = #{}
+              , core_nodes = []
+              },
+    {ok, State}.
 
-handle_info(?update, St) ->
-    do_update(),
+handle_info(?update, St0) ->
+    St = do_update(St0),
     {noreply, St};
 handle_info(_Info, St) ->
     {noreply, St}.
@@ -104,7 +114,9 @@ handle_call({probe, Node, Shard}, _From, St0 = #s{core_protocol_versions = Proto
         end,
     St = St0#s{core_protocol_versions = ProtoVSNs#{Node => ServerVersion}},
     {reply, Reply, St};
-handle_call(_From, Call, St) ->
+handle_call(core_nodes, _From, St = #s{core_nodes = CoreNodes}) ->
+    {reply, CoreNodes, St};
+handle_call(Call, _From, St) ->
     {reply, {error, {unknown_call, Call}}, St}.
 
 code_change(_OldVsn, St, _Extra) ->
@@ -117,13 +129,14 @@ terminate(_Reason, St) ->
 %% Internal functions
 %%================================================================================
 
-do_update() ->
-    [do_update(Shard) || Shard <- mria_schema:shards()],
-    init_timer().
+do_update(State) ->
+    NewCoreNodes = list_core_nodes(State#s.core_nodes),
+    [do_update_shard(Shard, NewCoreNodes) || Shard <- mria_schema:shards()],
+    init_timer(),
+    State#s{core_nodes = NewCoreNodes}.
 
-do_update(Shard) ->
+do_update_shard(Shard, CoreNodes) ->
     Timeout = application:get_env(mria, rlog_lb_update_timeout, 300),
-    CoreNodes = mria_rlog:core_nodes(),
     {Resp0, _} = rpc:multicall(CoreNodes, ?MODULE, core_node_weight, [Shard], Timeout),
     Resp = lists:sort([I || {ok, I} <- Resp0]),
     case Resp of
@@ -136,6 +149,59 @@ do_update(Shard) ->
 init_timer() ->
     Interval = application:get_env(mria, rlog_lb_update_interval, 1000),
     erlang:send_after(Interval + rand:uniform(Interval), self(), ?update).
+
+list_core_nodes(OldCoreNodes) ->
+    DefaultFun = fun() -> application:get_env(mria, core_nodes, []) end,
+    CallbackFun = application:get_env(mria, core_nodes_callback, DefaultFun),
+    NewCoreNodes0 = lists:usort(CallbackFun()),
+    case NewCoreNodes0 =:= OldCoreNodes of
+        true ->
+            ?tp(mria_lb_core_discovery_no_change, #{ old => OldCoreNodes
+                                                   , node => node()
+                                                   }),
+            OldCoreNodes;
+        false ->
+            case check_same_cluster(NewCoreNodes0) of
+                {ok, NewCoreNodes1} ->
+                    ?tp( mria_lb_core_discovery_new_nodes
+                       , #{ previous_cores => OldCoreNodes
+                          , returned_cores => NewCoreNodes1
+                          , node => node()
+                          }
+                       ),
+                    NewCoreNodes1;
+                {error, {unknown_nodes, UnknownNodes}} ->
+                    ?tp( error
+                       ,  mria_lb_core_discovery_divergent_cluster
+                       , #{ previous_cores => OldCoreNodes
+                          , returned_cores => NewCoreNodes0
+                          , unknown_nodes => UnknownNodes
+                          , node => node()
+                          }),
+                    OldCoreNodes
+            end
+    end.
+
+%% ensure that the nodes returned by the discovery callback are all
+%% from the same mnesia cluster.
+check_same_cluster(NewCoreNodes0) ->
+    NewCoreNodes1 = [N || N <- NewCoreNodes0,
+                          core =:= erpc:call(N, mria_rlog, role, [])],
+    DbNodes = lists:usort([N || {ok, Ns} <- erpc:multicall(NewCoreNodes1, mria_mnesia, db_nodes,
+                                                           [], ?CORE_DISCOVERY_TIMEOUT),
+                                  N <- Ns]),
+    UnknownNodes = DbNodes -- NewCoreNodes0,
+    ?tp(mria_lb_db_nodes_results,
+        #{ me => node()
+         , db_nodes => DbNodes
+         , new_unfiltered => NewCoreNodes0
+         , new_filtered_by_role => NewCoreNodes1
+         , unknown_nodes => UnknownNodes
+         }),
+    case UnknownNodes =:= [] of
+        true -> {ok, NewCoreNodes1};
+        false -> {error, {unknown_nodes, UnknownNodes}}
+    end.
 
 %%================================================================================
 %% Internal exports

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -151,9 +151,7 @@ init_timer() ->
     erlang:send_after(Interval + rand:uniform(Interval), self(), ?update).
 
 list_core_nodes(OldCoreNodes) ->
-    DefaultFun = fun() -> application:get_env(mria, core_nodes, []) end,
-    CallbackFun = application:get_env(mria, core_nodes_callback, DefaultFun),
-    NewCoreNodes0 = lists:usort(CallbackFun()),
+    NewCoreNodes0 = lists:usort(mria_lib:exec_callback(core_node_discovery)),
     case NewCoreNodes0 =:= OldCoreNodes of
         true ->
             ?tp(mria_lb_core_discovery_no_change, #{ old => OldCoreNodes

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -155,10 +155,6 @@ list_core_nodes(OldCoreNodes) ->
     NewCoreNodes0 = lists:usort(DiscoveryFun()),
     case NewCoreNodes0 =:= OldCoreNodes of
         true ->
-            ?tp(mria_lb_core_discovery_no_change,
-                #{ previous_cores => OldCoreNodes
-                 , node => node()
-                 }),
             OldCoreNodes;
         false ->
             case check_same_cluster(NewCoreNodes0) of

--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -342,7 +342,7 @@ shutdown_process(Pid) when is_pid(Pid) ->
             ok
     end.
 
--spec exec_callback(mria_config:callback()) -> ok.
+-spec exec_callback(mria_config:callback()) -> term().
 exec_callback(Name) ->
     ?tp(mria_exec_callback, #{type => Name}),
     case mria_config:callback(Name) of

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -43,6 +43,7 @@
         , running_nodes/0
         , is_node_in_cluster/0
         , is_node_in_cluster/1
+        , db_nodes/0
         ]).
 
 %% Dir, schema and tables
@@ -204,6 +205,11 @@ running_nodes() ->
                     []
             end
     end.
+
+%% @doc List Mnesia DB nodes.  Used by `mria_lb' to check if nodes
+%% reported by core discovery callback are in the same cluster.
+db_nodes() ->
+    mnesia:system_info(db_nodes).
 
 %% @doc Is this node in mnesia cluster?
 is_node_in_cluster() ->

--- a/src/mria_rlog.erl
+++ b/src/mria_rlog.erl
@@ -25,6 +25,7 @@
         , backend/0
 
         , core_nodes/0
+        , set_core_nodes_callback/1
         , subscribe/4
         , wait_for_shards/2
         ]).
@@ -80,7 +81,12 @@ backend() ->
 
 -spec core_nodes() -> [node()].
 core_nodes() ->
-    application:get_env(mria, core_nodes, []).
+    mria_lb:core_nodes().
+
+%% @doc Defines the core node discovery callback to be used.
+-spec set_core_nodes_callback(fun(() -> [node()])) -> ok.
+set_core_nodes_callback(CallbackFun) when is_function(CallbackFun, 0) ->
+    application:set_env(mria, core_nodes_callback, CallbackFun).
 
 -spec wait_for_shards([shard()], timeout()) -> ok | {timeout, [shard()]}.
 wait_for_shards(Shards0, Timeout) ->

--- a/src/mria_rlog.erl
+++ b/src/mria_rlog.erl
@@ -25,7 +25,6 @@
         , backend/0
 
         , core_nodes/0
-        , set_core_nodes_callback/1
         , subscribe/4
         , wait_for_shards/2
         ]).
@@ -82,11 +81,6 @@ backend() ->
 -spec core_nodes() -> [node()].
 core_nodes() ->
     mria_lb:core_nodes().
-
-%% @doc Defines the core node discovery callback to be used.
--spec set_core_nodes_callback(fun(() -> [node()])) -> ok.
-set_core_nodes_callback(CallbackFun) when is_function(CallbackFun, 0) ->
-    application:set_env(mria, core_nodes_callback, CallbackFun).
 
 -spec wait_for_shards([shard()], timeout()) -> ok | {timeout, [shard()]}.
 wait_for_shards(Shards0, Timeout) ->

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -113,7 +113,7 @@ t_probe(_Config) ->
                ok
        end).
 
-t_core_nodes(_Config) ->
+t_core_node_discovery(_Config) ->
     Cluster = mria_ct:cluster([core, replicant, core], mria_mnesia_test_util:common_env()),
     ?check_trace(
        #{timetrap => 60000},
@@ -173,10 +173,7 @@ t_core_nodes(_Config) ->
            ok
        after
            ok = mria_ct:teardown_cluster(Cluster)
-       end,
-       fun(_, _Trace) ->
-               ok
-       end).
+       end, []).
 
 clear_core_node_list(Replicant) ->
     CoresBefore = erpc:call(Replicant, application, get_env,

--- a/test/mria_mnesia_test_util.erl
+++ b/test/mria_mnesia_test_util.erl
@@ -30,14 +30,10 @@ wait_full_replication(Cluster, Timeout) ->
     mria_helper_tab:wait_full_replication(Cluster, Timeout).
 
 stabilize(Timeout) ->
-    case ?block_until(
-            #{ ?snk_meta := #{domain := [mria, rlog|_]}
-             , ?snk_kind := Kind
-             } when Kind =/= mria_lb_core_discovery_no_change,
-            Timeout, 0) of
+    case ?block_until(#{?snk_meta := #{domain := [mria, rlog|_]}}, Timeout, 0) of
         timeout -> ok;
         {ok, _Evt} ->
-            %% ct:pal("Restart waiting for cluster stabilize due to ~p", [_Evt]),
+            %%ct:pal("Restart waiting for cluster stabilize sue to ~p", [_Evt]),
             stabilize(Timeout)
     end.
 

--- a/test/mria_mnesia_test_util.erl
+++ b/test/mria_mnesia_test_util.erl
@@ -30,10 +30,14 @@ wait_full_replication(Cluster, Timeout) ->
     mria_helper_tab:wait_full_replication(Cluster, Timeout).
 
 stabilize(Timeout) ->
-    case ?block_until(#{?snk_meta := #{domain := [mria, rlog|_]}}, Timeout, 0) of
+    case ?block_until(
+            #{ ?snk_meta := #{domain := [mria, rlog|_]}
+             , ?snk_kind := Kind
+             } when Kind =/= mria_lb_core_discovery_no_change,
+            Timeout, 0) of
         timeout -> ok;
         {ok, _Evt} ->
-            %%ct:pal("Restart waiting for cluster stabilize sue to ~p", [_Evt]),
+            %% ct:pal("Restart waiting for cluster stabilize due to ~p", [_Evt]),
             stabilize(Timeout)
     end.
 


### PR DESCRIPTION
Fixes #36 .

This adds a callback that can be registered to list the core nodes
instead of reading a fixed list from config.  This should help when
discovering core nodes via discovery mechanisms such as etcd, Consul
and others.