### PR TITLE
chore(rocksdb): Bump dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.16.0"}}},
         {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.7.0"}}},
         {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.1"}}},
-        {mnesia_rocksdb, {git, "https://github.com/k32/mnesia_rocksdb", {tag, "0.1.3-k32"}}}
+        {mnesia_rocksdb, {git, "https://github.com/k32/mnesia_rocksdb", {tag, "0.1.4-k32"}}}
        ]}.
 
 {erl_opts, [warn_unused_vars,


### PR DESCRIPTION
This is a small change that disables liburing detection by default, since it's known to cause problems on some distributives.