### PR TITLE
fix(running_nodes): add timeout to `running_nodes`

### DIFF
--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -189,7 +189,7 @@ running_nodes() ->
     case mria_rlog:role() of
         core ->
             CoreNodes = mnesia:system_info(running_db_nodes),
-            {Replicants0, _} = rpc:multicall(CoreNodes, mria_status, replicants, []),
+            {Replicants0, _} = rpc:multicall(CoreNodes, mria_status, replicants, [], 15000),
             Replicants = [Node || Nodes <- Replicants0, is_list(Nodes), Node <- Nodes],
             lists:usort(CoreNodes ++ Replicants);
         replicant ->


### PR DESCRIPTION
Fixes #49 .

Since `mria_node_monitor` calls `mria_mnesia:running_nodes/0`, and
there's a `rpc:multicall` contained in it, that can hang indefinetely,
making the former process' message queue bloat.