### PR TITLE
fix: return cores from replicant

### DIFF
--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -212,17 +212,7 @@ cluster_nodes(cores) ->
         core ->
             db_nodes();
         replicant ->
-            case mria_status:shards_up() of
-                [Shard | _] ->
-                    {ok, CoreNode} = mria_status:upstream_node(Shard),
-                    case mria_lib:rpc_call(CoreNode, ?MODULE, ?FUNCTION_NAME, [cores]) of
-                        {badrpc, _} -> [];
-                        {badtcp, _} -> [];
-                        Result      -> Result
-                    end;
-                [] ->
-                    []
-            end
+            mria_lb:core_nodes()
     end.
 
 %% @doc Running nodes.

--- a/test/mria_mnesia_SUITE.erl
+++ b/test/mria_mnesia_SUITE.erl
@@ -1,0 +1,60 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(mria_mnesia_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+all() ->
+    mria_ct:all(?MODULE).
+
+init_per_suite(Config) ->
+    snabbkaffe:fix_ct_logging(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    logger:notice(asciiart:visible($%, "Starting ~p", [TestCase])),
+    ok = snabbkaffe:start_trace(),
+    Config.
+
+end_per_testcase(TestCase, Config) ->
+    logger:notice(asciiart:visible($%, "Complete ~p", [TestCase])),
+    mria_ct:cleanup(TestCase),
+    snabbkaffe:stop(),
+    Config.
+
+t_cluster_core_nodes_on_replicant(_) ->
+    Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       #{timetrap => 10000},
+       try
+           [N1, N2] = mria_ct:start_cluster(mria, Cluster),
+           mria_mnesia_test_util:wait_full_replication(Cluster, 5000),
+           ?assertEqual(
+              [N1],
+              erpc:call(N2, mria_mnesia, cluster_nodes, [cores])),
+           ok
+       after
+           ok = mria_ct:teardown_cluster(Cluster)
+       end,
+       []).

--- a/test/mria_proper_mixed_cluster_suite.erl
+++ b/test/mria_proper_mixed_cluster_suite.erl
@@ -47,6 +47,18 @@ initial_state() ->
     #s{cores = [n1, n2], replicants = [n3]}.
 
 command(State) -> mria_proper_utils:command(State).
+precondition(_State, {call, _Mod, execute, [_Node, Op]}) ->
+    %% With more than one core, a race condition involving a
+    %% `dirty_write' / `dirty_delete' pair of ops happening on
+    %% different cores can arise: one of the cores might process the
+    %% dirty ops in a different order than what the state machine
+    %% expects, thus violating the model consistency.  Since this is
+    %% inherent to mnesia, for this test we simply forbid dirty
+    %% operations altogether.
+    case Op of
+        {dirty, _} -> false;
+        _ -> true
+    end;
 precondition(State, Op) -> mria_proper_utils:precondition(State, Op).
 postcondition(State, Op, Res) -> mria_proper_utils:postcondition(State, Op, Res).
 next_state(State, Res, Op) -> mria_proper_utils:next_state(State, Res, Op).

--- a/test/mria_proper_utils.erl
+++ b/test/mria_proper_utils.erl
@@ -197,7 +197,7 @@ cluster_node(Names) ->
 
 get_records(Node, Table) ->
     {atomic, Records} =
-        rpc:call(Node, mria, ro_transaction,
+        rpc:call(Node, mria, transaction,
                  [ test_shard
                  , fun() ->
                            mnesia:foldr(fun(Record, Acc) -> [Record | Acc] end, [], Table)

--- a/test/mria_proper_utils.erl
+++ b/test/mria_proper_utils.erl
@@ -130,8 +130,8 @@ check_state(Cmds, #s{bag = Bag, set = Set}, Node) ->
     compare_lists(set, Node, Cmds, lists:sort(maps:to_list(Set)), get_records(Node, test_tab)).
 
 compare_lists(Type, Node, Cmds, Expected, Got) ->
-    Unexpected = Expected -- Got,
-    Missing = Got -- Expected,
+    Missing = Expected -- Got,
+    Unexpected = Got -- Expected,
     Comment = [ {node, Node}
               , {cmds, Cmds}
               , {unexpected, Unexpected}


### PR DESCRIPTION
Fixes #75 .

Calling `mnesia:system_info(db_nodes)` on a replicant will return only
the replicant self node.  We need to check with the upstream core the
true list of all core nodes.