### PR TITLE
Fix: consider only core nodes in autoheal and in membership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ REBAR := rebar3
 
 CT_NODE_NAME = ct@127.0.0.1
 
+CT_READABLE ?= false
+
 compile:
 	$(REBAR) do compile, dialyzer, xref
 
@@ -30,22 +32,22 @@ test: smoke-test ct-consistency ct-fault-tolerance cover
 
 .PHONY: smoke-test
 smoke-test:
-	$(REBAR) do eunit, ct -v --readable=false --name $(CT_NODE_NAME)
+	$(REBAR) do eunit, ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME)
 
 .PHONY: ct-consistency
 ct-consistency:
-	$(REBAR) ct -v --readable=false --name $(CT_NODE_NAME) --suite mria_proper_suite,mria_proper_mixed_cluster_suite
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite mria_proper_suite,mria_proper_mixed_cluster_suite
 
 .PHONY: ct-fault-tolerance
 ct-fault-tolerance:
-	$(REBAR) ct -v --readable=false --name $(CT_NODE_NAME) --suite mria_fault_tolerance_suite
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite mria_fault_tolerance_suite
 
 .PHONY: ct-suite
 ct-suite: compile
 ifneq ($(TESTCASE),)
-	$(REBAR) ct -v --readable=false --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
 else
-	$(REBAR) ct -v --readable=false --name $(CT_NODE_NAME) --suite $(SUITE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
 endif
 
 cover: | smoke-test ct-consistency ct-fault-tolerance

--- a/include/mria.hrl
+++ b/include/mria.hrl
@@ -11,7 +11,8 @@
           hash   :: undefined | pos_integer(),
           status :: member_status(),
           mnesia :: undefined | running | stopped | false,
-          ltime  :: undefined | erlang:timestamp()
+          ltime  :: undefined | erlang:timestamp(),
+          role   :: mria_rlog:role()
          }).
 
 -type(member() :: #member{}).

--- a/src/mria_autoheal.erl
+++ b/src/mria_autoheal.erl
@@ -78,7 +78,7 @@ handle_msg(Msg = {create_splitview, Node}, Autoheal = #autoheal{delay = Delay, t
     ensure_cancel_timer(TRef),
     case mria_membership:is_all_alive() of
         true ->
-            Nodes = mria_mnesia:cluster_nodes(all),
+            Nodes = mria_mnesia:cluster_nodes(cores),
             case rpc:multicall(Nodes, mria_mnesia, cluster_view, []) of
                 {Views, []} ->
                     SplitView = lists:sort(fun compare_view/2, lists:usort(Views)),
@@ -134,7 +134,7 @@ heal_partition([]) ->
 heal_partition([{_, []}]) ->
     [];
 %% Partial partitions happened.
-heal_partition([{Nodes, []}|_]) ->
+heal_partition([{Nodes, []} | _]) ->
     reboot_minority(Nodes -- [node()]);
 heal_partition([{Majority, Minority}, {Minority, Majority}]) ->
     reboot_minority(Minority);

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -194,8 +194,13 @@ cluster_status(Node) ->
 
 -spec(cluster_view() -> {[node()], [node()]}).
 cluster_view() ->
-    list_to_tuple([lists:sort(cluster_nodes(Status))
-                   || Status <- [running, stopped]]).
+    Cores = sets:from_list(cluster_nodes(cores)),
+    Running0 = sets:from_list(cluster_nodes(running)),
+    Stopped0 = sets:from_list(cluster_nodes(stopped)),
+    Running = sets:intersection(Cores, Running0),
+    Stopped = sets:intersection(Cores, Stopped0),
+    list_to_tuple([lists:sort(sets:to_list(Nodes))
+                   || Nodes <- [Running, Stopped]]).
 
 %% @doc Cluster nodes.
 -spec(cluster_nodes(all | running | stopped | cores) -> [node()]).

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -194,13 +194,9 @@ cluster_status(Node) ->
 
 -spec(cluster_view() -> {[node()], [node()]}).
 cluster_view() ->
-    Cores = sets:from_list(cluster_nodes(cores)),
-    Running0 = sets:from_list(cluster_nodes(running)),
-    Stopped0 = sets:from_list(cluster_nodes(stopped)),
-    Running = sets:intersection(Cores, Running0),
-    Stopped = sets:intersection(Cores, Stopped0),
-    list_to_tuple([lists:sort(sets:to_list(Nodes))
-                   || Nodes <- [Running, Stopped]]).
+    list_to_tuple([lists:sort([N || N <- cluster_nodes(Status),
+                                    mria_rlog:role(N) =:= core])
+                   || Status <- [running, stopped]]).
 
 %% @doc Cluster nodes.
 -spec(cluster_nodes(all | running | stopped | cores) -> [node()]).

--- a/src/mria_rlog.erl
+++ b/src/mria_rlog.erl
@@ -113,6 +113,8 @@ role(Node) ->
 backend() ->
     mria_config:backend().
 
+%% @doc Should be only called in a replicant node.  Returns the list
+%% of core nodes cached in `mria_lb'.
 -spec core_nodes() -> [node()].
 core_nodes() ->
     mria_lb:core_nodes().

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -49,9 +49,6 @@ t_autoheal(Config) when is_list(Config) ->
                       [N1,N2,N3] = rpc:call(N2, mria, info, [running_nodes]),
                       [N1,N2,N3] = rpc:call(N3, mria, info, [running_nodes])
                   end),
-           rpc:call(N1, mria, leave, []),
-           rpc:call(N2, mria, leave, []),
-           rpc:call(N3, mria, leave, []),
            [N1, N2, N3]
        after
            ok = mria_ct:teardown_cluster(Cluster)
@@ -104,9 +101,6 @@ t_autoheal_with_replicants(Config) when is_list(Config) ->
                       [N1,N2,N3,N4,N5] = rpc:call(N5, mria, info, [running_nodes]),
                       ok
                   end),
-           rpc:call(N1, mria, leave, []),
-           rpc:call(N2, mria, leave, []),
-           rpc:call(N3, mria, leave, []),
            [N1, N2, N3]
        after
            ok = mria_ct:teardown_cluster(Cluster)

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -17,6 +17,7 @@
 -module(mria_autoheal_SUITE).
 
 -export([ t_autoheal/1
+        , t_autoheal_with_replicants/1
         , t_reboot_rejoin/1
         ]).
 
@@ -65,7 +66,63 @@ t_autoheal(Config) when is_list(Config) ->
                {_, Rest} = ?split_trace_at(#{?snk_kind := "Rebooting minority"}, Trace),
                ?assertMatch( [stop, start|_]
                            , ?projection(type, ?of_kind(mria_exec_callback, ?of_node(N3, Rest)))
-                           )
+                           ),
+               ok
+       end).
+
+t_autoheal_with_replicants(Config) when is_list(Config) ->
+    snabbkaffe:fix_ct_logging(),
+    Cluster = mria_ct:cluster([ core
+                              , core
+                              , core
+                              , replicant
+                              , replicant
+                              ],
+                              [ {mria, cluster_autoheal, 200}
+                              | mria_mnesia_test_util:common_env()
+                              ]),
+    ?check_trace(
+       #{timetrap => 45_000},
+       try
+           Nodes = [N1, N2, N3, N4, N5] = mria_ct:start_cluster(mria, Cluster),
+           ok = mria_mnesia_test_util:wait_tables(Nodes),
+           %% Simulate netsplit
+           true = rpc:cast(N1, net_kernel, disconnect, [N2]),
+           true = rpc:cast(N1, net_kernel, disconnect, [N3]),
+           ok = timer:sleep(1000),
+           %% SplitView: {[N2,N3], [N1]}
+           assert_partition_contents(N1, #{running => [N1], stopped => [N2, N3]}),
+           assert_partition_contents(N2, #{running => [N2, N3], stopped => [N1]}),
+           assert_partition_contents(N3, #{running => [N2, N3], stopped => [N1]}),
+           %% Wait for autoheal, it should happen automatically:
+           ?retry(1000, 20,
+                  begin
+                      [N1,N2,N3,N4,N5] = rpc:call(N1, mria, info, [running_nodes]),
+                      [N1,N2,N3,N4,N5] = rpc:call(N2, mria, info, [running_nodes]),
+                      [N1,N2,N3,N4,N5] = rpc:call(N3, mria, info, [running_nodes]),
+                      [N1,N2,N3,N4,N5] = rpc:call(N4, mria, info, [running_nodes]),
+                      [N1,N2,N3,N4,N5] = rpc:call(N5, mria, info, [running_nodes]),
+                      ok
+                  end),
+           rpc:call(N1, mria, leave, []),
+           rpc:call(N2, mria, leave, []),
+           rpc:call(N3, mria, leave, []),
+           [N1, N2, N3]
+       after
+           ok = mria_ct:teardown_cluster(Cluster)
+       end,
+       fun([N1, _N2, _N3], Trace) ->
+               ?assert(
+                  ?causality( #{?snk_kind := mria_exec_callback, type := start, ?snk_meta := #{node := _N}}
+                            , #{?snk_kind := mria_exec_callback, type := stop,  ?snk_meta := #{node := _N}}
+                            , Trace
+                            )),
+               %% Check that restart callbacks were called after partition was healed:
+               {_, Rest} = ?split_trace_at(#{?snk_kind := "Rebooting minority"}, Trace),
+               ?assertMatch( [stop, start|_]
+                           , ?projection(type, ?of_kind(mria_exec_callback, ?of_node(N1, Rest)))
+                           ),
+               ok
        end).
 
 t_reboot_rejoin(Config) when is_list(Config) ->
@@ -146,4 +203,19 @@ assert_replicant_bootstrapped(R, C, Trace) ->
                         , Trace
                         )),
     mria_rlog_props:replicant_bootstrap_stages(R, Trace),
+    ok.
+
+assert_partition_contents(Node, #{ running := ExpectedRunning
+                                 , stopped := ExpectedStopped
+                                 }) ->
+    Running = rpc:call(Node, mria, info, [running_nodes]),
+    Stopped = rpc:call(Node, mria, info, [stopped_nodes]),
+    [?assert(lists:member(Expected, Running), #{ node => Node
+                                               , expected => Expected
+                                               })
+     || Expected <- ExpectedRunning],
+    [?assert(lists:member(Expected, Stopped), #{ node => Node
+                                               , expected => Expected
+                                               })
+     || Expected <- ExpectedStopped],
     ok.

--- a/test/mria_membership_SUITE.erl
+++ b/test/mria_membership_SUITE.erl
@@ -164,7 +164,7 @@ t_replicant_init(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       [fun assert_no_replicants_inserted/1]).
+       [fun ?MODULE:assert_no_replicants_inserted/1]).
 
 %%--------------------------------------------------------------------
 %% Helper functions
@@ -216,11 +216,12 @@ test_core_ping_pong(PingOrPong) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       [ fun assert_no_replicants_inserted/1
-       , fun(Trace0) ->
-                 {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
-                 assert_cores_always_get_inserted(Trace)
-         end
+       [ fun ?MODULE:assert_no_replicants_inserted/1
+       , {"cores always get inserted",
+          fun(Trace0) ->
+                  {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
+                  assert_cores_always_get_inserted(Trace)
+          end}
        ]).
 
 test_replicant_ping_pong(PingOrPong) ->
@@ -253,18 +254,19 @@ test_replicant_ping_pong(PingOrPong) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       [ fun assert_no_replicants_inserted/1
-       , fun(Trace0) ->
-                 case PingOrPong of
-                     ping ->
-                         {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
-                         assert_cores_always_get_inserted(Trace);
-                     pong ->
-                         %% pongs from replicants do not result in
-                         %% cores being inserted.
-                         ok
-                 end
-         end
+       [ fun ?MODULE:assert_no_replicants_inserted/1
+       , {"cores get inserted on ping",
+          fun(Trace0) ->
+                  case PingOrPong of
+                      ping ->
+                          {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
+                          assert_cores_always_get_inserted(Trace);
+                      pong ->
+                          %% pongs from replicants do not result in
+                          %% cores being inserted.
+                          ok
+                  end
+          end}
        ]).
 
 assert_expected_memberships(Node, Cores) ->

--- a/test/mria_membership_SUITE.erl
+++ b/test/mria_membership_SUITE.erl
@@ -21,6 +21,7 @@
 
 -include("mria.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() -> mria_ct:all(?MODULE).
 
@@ -124,6 +125,47 @@ t_force_leave(_) ->
         mria_ct:teardown_cluster(Cluster)
     end.
 
+t_ping_from_cores(_) ->
+    test_core_ping_pong(ping).
+
+t_ping_from_replicants(_) ->
+    test_replicant_ping_pong(ping).
+
+t_pong_from_cores(_) ->
+    test_core_ping_pong(pong).
+
+t_pong_from_replicants(_) ->
+    test_replicant_ping_pong(pong).
+
+%% replicants do not insert themselves into the membership table, and
+%% they insert cores during loadbalancer initialization.
+t_replicant_init(_) ->
+    Cluster = mria_ct:cluster([core, core, replicant, replicant],
+                              mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       try
+           Nodes = [N0, N1, _N2, _N3] = mria_ct:start_cluster(mria, Cluster),
+           ok = mria_mnesia_test_util:wait_tables(Nodes),
+           Cores = [N0, N1],
+           [begin
+                ?assertMatch([_, _], erpc:call(N, mria_membership, members, []),
+                             #{node => N}),
+                [?assert(erpc:call(N, mria_membership, is_member, [M]),
+                         #{node => N, other => M})
+                 || M <- Cores],
+                Leader = erpc:call(N, mria_membership, leader, []),
+                Coordinator = erpc:call(N, mria_membership, coordinator, []),
+                ?assert(lists:member(Leader, Cores), #{node => N}),
+                ?assert(lists:member(Coordinator, Cores), #{node => N}),
+                ok
+            end
+            || N <- Nodes],
+           ok
+       after
+           mria_ct:teardown_cluster(Cluster)
+       end,
+       [fun assert_no_replicants_inserted/1]).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
@@ -145,3 +187,120 @@ member(I) ->
             mnesia = running,
             ltime  = erlang:timestamp()
            }.
+
+test_core_ping_pong(PingOrPong) ->
+    Cluster = mria_ct:cluster([core, core, replicant, replicant],
+                              mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       try
+           Nodes = [N0, N1, _N2, _N3] = mria_ct:start_cluster(mria, Cluster),
+           ok = mria_mnesia_test_util:wait_tables(Nodes),
+           Cores = [N0, N1],
+           ?tp(done_waiting_for_tables, #{}),
+           [begin
+                %% Cores do have themselves as local members.
+                LocalMember = erpc:call(N, mria_membership, local_member, []),
+                lists:foreach(
+                  fun(M) ->
+                          ?wait_async_action(
+                             mria_membership:PingOrPong(M, LocalMember),
+                             #{ ?snk_kind := mria_membership_pong
+                              , member := #member{node = N}
+                              }, 1000)
+                  end, Nodes),
+                assert_expected_memberships(N, Cores),
+                ok
+            end
+            || N <- Cores],
+           ok
+       after
+           mria_ct:teardown_cluster(Cluster)
+       end,
+       [ fun assert_no_replicants_inserted/1
+       , fun(Trace0) ->
+                 {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
+                 assert_cores_always_get_inserted(Trace)
+         end
+       ]).
+
+test_replicant_ping_pong(PingOrPong) ->
+    Cluster = mria_ct:cluster([core, core, replicant, replicant],
+                              mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       try
+           Nodes = [N0, N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
+           ok = mria_mnesia_test_util:wait_tables(Nodes),
+           Cores = [N0, N1],
+           Replicants = [N2, N3],
+           ?tp(done_waiting_for_tables, #{}),
+           [begin
+                %% Replicants do not have themselves as local members.
+                %% We make an entry on the fly.
+                LocalMember = erpc:call(N, mria_membership, make_new_local_member, []),
+                lists:foreach(
+                  fun(M) ->
+                          ?wait_async_action(
+                             mria_membership:PingOrPong(M, LocalMember),
+                             #{ ?snk_kind := mria_membership_pong
+                              , member := #member{node = N}
+                              }, 1000)
+                  end, Nodes),
+                assert_expected_memberships(N, Cores),
+                ok
+            end
+            || N <- Replicants],
+           ok
+       after
+           mria_ct:teardown_cluster(Cluster)
+       end,
+       [ fun assert_no_replicants_inserted/1
+       , fun(Trace0) ->
+                 case PingOrPong of
+                     ping ->
+                         {_, Trace} = ?split_trace_at(#{?snk_kind := done_waiting_for_tables}, Trace0),
+                         assert_cores_always_get_inserted(Trace);
+                     pong ->
+                         %% pongs from replicants do not result in
+                         %% cores being inserted.
+                         ok
+                 end
+         end
+       ]).
+
+assert_expected_memberships(Node, Cores) ->
+    Members = erpc:call(Node, mria_membership, members, []),
+    ReplicantMembers = [Member || Member = #member{role = replicant} <- Members],
+    {PresentCores, UnknownCores} =
+        lists:partition(
+          fun(N) ->
+                  lists:member(N, Cores)
+          end,
+          [N || #member{role = core, node = N} <- Members]),
+    ?assertEqual([], ReplicantMembers, #{node => Node}),
+    ?assertEqual([], UnknownCores, #{node => Node}),
+    %% cores get inserted into replicants' tables either by the pings
+    %% sent from cores, or by the core discovery procedure.
+    ?assertEqual(lists:usort(Cores), lists:usort(PresentCores), #{node => Node}),
+    ok.
+
+assert_no_replicants_inserted(Trace) ->
+    ?assertEqual([], [Event || Event = #{ ?snk_kind := mria_membership_insert
+                                        , member := #member{role = replicant}
+                                        } <- Trace]).
+
+assert_cores_always_get_inserted(Trace) ->
+    ?assert(
+      ?strict_causality(
+         #{ ?snk_kind := EventType
+          , ?snk_meta := #{node := _Node}
+          , member := #member{role = core, node = _MemberNode,
+                              status = up, mnesia = running}
+          } when EventType =:= mria_membership_ping;
+                 EventType =:= mria_membership_pong
+        , #{ ?snk_kind := mria_membership_insert
+           , ?snk_meta := #{node := _Node}
+           , member := #member{role = core, node = _MemberNode,
+                               status = up, mnesia = running}
+           }
+        , Trace
+        )).


### PR DESCRIPTION
- Adds the node role to the membership record.
- Consider only core nodes when listing nodes to consider for the autoheal / splitview feature.
- Only insert core nodes into the local membership table, so replicants don't get used as leaders nor coordinators.