### PR TITLE
fix(txn): do not wait on shard during transaction

### DIFF
--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -195,7 +195,6 @@ call_backend_rw_dirty(Function, Table, Args) ->
 -spec transactional_wrapper(mria_rlog:shard(), atom(), list()) -> mria:t_result(term()).
 transactional_wrapper(Shard, Fun, Args) ->
     ensure_no_transaction(),
-    mria_rlog:wait_for_shards([Shard], infinity),
     mnesia:transaction(fun() ->
                                Res = apply(mria_activity, Fun, Args),
                                {_TID, TxStore} = get_internals(),

--- a/src/mria_shards_sup.erl
+++ b/src/mria_shards_sup.erl
@@ -42,9 +42,11 @@ find_shard(Shard) ->
 -spec start_shard(mria_rlog:shard()) -> {ok, pid()}
                                       | {error, _}.
 start_shard(Shard) ->
-    ?tp(info, "Starting RLOG shard",
-        #{ shard => Shard
-         }),
+    LogLevel = case mria_config:role() of
+                   core -> debug;
+                   replicant -> info
+               end,
+    ?tp(LogLevel, "Starting RLOG shard", #{shard => Shard}),
     Child = shard_sup(Shard),
     supervisor:start_child(?SUPERVISOR, Child).
 

--- a/src/mria_shards_sup.erl
+++ b/src/mria_shards_sup.erl
@@ -46,7 +46,7 @@ start_shard(Shard) ->
                    core -> debug;
                    replicant -> info
                end,
-    ?tp(LogLevel, "Starting RLOG shard", #{shard => Shard}),
+    ?tp(LogLevel, "starting_rlog_shard", #{shard => Shard}),
     Child = shard_sup(Shard),
     supervisor:start_child(?SUPERVISOR, Child).
 

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -183,7 +183,7 @@ wait_for_shards(Shards, Timeout) ->
                    core -> debug;
                    replicant -> info
                end,
-    ?tp(LogLevel, "Waiting for shards",
+    ?tp(LogLevel, "waiting_for_shards",
         #{ shards => Shards
          , timeout => Timeout
          }),
@@ -195,7 +195,7 @@ wait_for_shards(Shards, Timeout) ->
                   %% Unzip to transform `[{upstream_shard, foo}, {upstream_shard, bar}]' to `[foo, bar]':
                   {timeout, element(2, lists:unzip(L))}
           end,
-    ?tp(LogLevel, "Done waiting for shards",
+    ?tp(LogLevel, "done_waiting_for_shards",
         #{ shards => Shards
          , result => Ret
          }),

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -179,7 +179,11 @@ get_core_node(Shard, Timeout) ->
 
 -spec wait_for_shards([mria_rlog:shard()], timeout()) -> ok | {timeout, [mria_rlog:shard()]}.
 wait_for_shards(Shards, Timeout) ->
-    ?tp(info, "Waiting for shards",
+    LogLevel = case mria_config:role() of
+                   core -> debug;
+                   replicant -> info
+               end,
+    ?tp(LogLevel, "Waiting for shards",
         #{ shards => Shards
          , timeout => Timeout
          }),
@@ -191,7 +195,7 @@ wait_for_shards(Shards, Timeout) ->
                   %% Unzip to transform `[{upstream_shard, foo}, {upstream_shard, bar}]' to `[foo, bar]':
                   {timeout, element(2, lists:unzip(L))}
           end,
-    ?tp(info, "Done waiting for shards",
+    ?tp(LogLevel, "Done waiting for shards",
         #{ shards => Shards
          , result => Ret
          }),

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -174,7 +174,7 @@ t_reboot_rejoin(Config) when is_list(Config) ->
                                       , status := #{ running_nodes := [_, _]
                                                    }
                                       }
-                                   , #{ ?snk_kind := "Starting RLOG shard"
+                                   , #{ ?snk_kind := "starting_rlog_shard"
                                       , shard := test_shard
                                       }
                                    , TraceC2


### PR DESCRIPTION
Also, reduces some message log levels about waiting for shards to
debug on cores, where such messages are not so useful.