### PR TITLE
test: fix flaky test

### DIFF
--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -103,6 +103,7 @@ t_rocksdb_table(_) ->
                                             {record_name, kv_tab},
                                             {attributes, record_info(fields, kv_tab)}
                                            ]),
+                    mria_rlog:wait_for_shards([test_shard], 5_000),
                     {atomic, Ret} =
                         mria:transaction(test_shard,
                                          fun() ->


### PR DESCRIPTION
Now that we removed `wait_for_shards` from each transaction, this test
needs to explicitly wait for the shard to avoid a race condition where
the rlog server is not done setting up yet.