### PR TITLE
feat: support mnesia:dirty_update_counter/3

### DIFF
--- a/src/mria.erl
+++ b/src/mria.erl
@@ -48,6 +48,9 @@
         , dirty_write_sync/2
         , dirty_write_sync/1
 
+        , dirty_update_counter/2
+        , dirty_update_counter/3
+
         , dirty_delete/2
         , dirty_delete/1
 
@@ -335,6 +338,14 @@ dirty_write_sync(Record) ->
 -spec dirty_write_sync(mria:table(), tuple()) -> ok.
 dirty_write_sync(Tab, Record) ->
     mria_lib:call_backend_rw_dirty(mria_lib, dirty_write_sync, Tab, [Record]).
+
+-spec dirty_update_counter(mria:table(), term(), integer()) -> integer().
+dirty_update_counter(Tab, Key, Incr) ->
+    mria_lib:call_backend_rw_dirty(dirty_update_counter, Tab, [Key, Incr]).
+
+-spec dirty_update_counter({mria:table(), term()}, integer()) -> integer().
+dirty_update_counter({Tab, Key}, Incr) ->
+    dirty_update_counter(Tab, Key, Incr).
 
 -spec dirty_delete(mria:table(), term()) -> ok.
 dirty_delete(Tab, Key) ->

--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -164,8 +164,8 @@ import_op_dirty(Op) ->
             mnesia:dirty_delete({Tab, Key});
         {delete_object, Tab, Rec} ->
             mnesia:dirty_delete_object(Tab, Rec);
-        {update_counter, Tab, Key, Inrc} ->
-            mnesia:dirty_update_counter(Tab, Key, Inrc);
+        {update_counter, Tab, Key, Incr} ->
+            mnesia:dirty_update_counter(Tab, Key, Incr);
         {clear_table, Tab} ->
             mnesia:clear_table(Tab)
     end.

--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -164,6 +164,8 @@ import_op_dirty(Op) ->
             mnesia:dirty_delete({Tab, Key});
         {delete_object, Tab, Rec} ->
             mnesia:dirty_delete_object(Tab, Rec);
+        {update_counter, Tab, Key, Inrc} ->
+            mnesia:dirty_update_counter(Tab, Key, Inrc);
         {clear_table, Tab} ->
             mnesia:clear_table(Tab)
     end.

--- a/src/mria_rlog_server.erl
+++ b/src/mria_rlog_server.erl
@@ -277,6 +277,8 @@ transform_op({{Tab, Key}, _Rec, delete}) ->
     {delete, Tab, Key};
 transform_op({{Tab, _Key}, Rec, delete_object}) ->
     {delete_object, Tab, Rec};
+transform_op({{Tab, Key}, {_, Incr}, update_counter}) ->
+    {update_counter, Tab, Key, Incr};
 transform_op({{Tab, '_'}, '_', clear_table}) ->
     {clear_table, Tab}.
 


### PR DESCRIPTION
When I use `mria:create_table/2` to create a counter table and use `mneisa:dirty_update_counter/3` in the core node, I get the following error message:

```
v5.0.12-g020c43d8(core1@127.0.0.1)10> mria:create_table(counter_table, [{type, set},{rlog_shard, emqx_tenancy_shard}]).
ok
v5.0.12-g020c43d8(core1@127.0.0.1)11> mnesia:dirty_update_counter(counter_table, key, 1).
1
v5.0.12-g020c43d8(core1@127.0.0.1)12> 
2023-01-06T16:00:50.583580+08:00 [error] Generic server emqx_tenancy_shard terminating. Reason: {function_clause,[{mria_rlog_server,transform_op,[{{counter_table,key},{counter_table,1},update_counter}],[{file,"mria_rlog_server.erl"},{line,274}]},{mria_rlog_server,'-transform_commit/2-lc$^0/1-2-',2,[{file,"mria_rlog_server.erl"},{line,261}]},{maps,fold_1,3,[{file,"maps.erl"},{line,410}]},{mria_rlog_server,transform_commit,2,[{file,"mria_rlog_server.erl"},{line,257}]},{mria_rlog_server,handle_info,2,[{file,"mria_rlog_server.erl"},{line,131}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}. Last message: {trans,{dirty,<0.2850.0>},#{disc_copies => [],disc_only_copies => [],ext => [],node => 'core1@127.0.0.1',ram_copies => [{{counter_table,key},{counter_table,1},update_counter}],schema_ops => []}}. State: {s,emqx_tenancy_shard,<0.2428.0>,<0.2761.0>,<0.2762.0>,30,3000,[],219}.
2023-01-06T16:00:50.584284+08:00 [error] crasher: initial call: mria_rlog_server:init/1, pid: <0.2429.0>, registered_name: emqx_tenancy_shard, error: {function_clause,[{mria_rlog_server,transform_op,[{{counter_table,key},{counter_table,1},update_counter}],[{file,"mria_rlog_server.erl"},{line,274}]},{mria_rlog_server,'-transform_commit/2-lc$^0/1-2-',2,[{file,"mria_rlog_server.erl"},{line,261}]},{maps,fold_1,3,[{file,"maps.erl"},{line,410}]},{mria_rlog_server,transform_commit,2,[{file,"mria_rlog_server.erl"},{line,257}]},{mria_rlog_server,handle_info,2,[{file,"mria_rlog_server.erl"},{line,131}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2428.0>,mria_shards_sup,mria_rlog_sup,mria_sup,<0.1848.0>], message_queue_len: 0, messages: [], links: [<0.2428.0>,<0.1862.0>], dictionary: [{'$logger_metadata$',#{domain => [mria,rlog,server],shard => emqx_tenancy_shard}}], trap_exit: true, status: running, heap_size: 6772, stack_size: 29, reductions: 30256; neighbours:
2023-01-06T16:00:50.585049+08:00 [error] Supervisor: {<0.2428.0>,mria_core_shard_sup}. Context: child_terminated. Reason: {function_clause,[{mria_rlog_server,transform_op,[{{counter_table,key},{counter_table,1},update_counter}],[{file,"mria_rlog_server.erl"},{line,274}]},{mria_rlog_server,'-transform_commit/2-lc$^0/1-2-',2,[{file,"mria_rlog_server.erl"},{line,261}]},{maps,fold_1,3,[{file,"maps.erl"},{line,410}]},{mria_rlog_server,transform_commit,2,[{file,"mria_rlog_server.erl"},{line,257}]},{mria_rlog_server,handle_info,2,[{file,"mria_rlog_server.erl"},{line,131}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}. Offender: id=mria_rlog_server,pid=<0.2429.0>.
2023-01-06T16:00:50.585421+08:00 [error] Supervisor: {<0.2428.0>,mria_core_shard_sup}. Context: shutdown. Reason: reached_max_restart_intensity. Offender: id=mria_rlog_server,pid=<0.2429.0>.
2023-01-06T16:00:50.585810+08:00 [error] Supervisor: {local,mria_shards_sup}. Context: child_terminated. Reason: shutdown. Offender: id=emqx_tenancy_shard,pid=<0.2428.0>.
```
I guess it's because mria doesn't support that operation yet, so I've made some fixes. But I'm not good with this library, so I'd appreciate your reviews 😃 
