### PR TITLE
OTP 25

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -12,12 +12,13 @@ jobs:
             os:
               - ubuntu20.04
             otp:
-              - 24.1.5-4
+              - 24.3.4.2-1
+              - 25.1.2-2
             elixir:
-              - 1.13.2
+              - 1.13.4
             arch:
               - amd64
-        container: ghcr.io/emqx/emqx-builder/5.0-5:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+        container: ghcr.io/emqx/emqx-builder/5.0-26:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
         steps:
         - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ TEST-*.xml
 concuerror_report.txt
 snabbkaffe/
 rebar3.crashdump
+.#*
+*~
+*#

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ BUILD_DIR := $(CURDIR)/_build
 
 REBAR := rebar3
 
-CT_NODE_NAME = ct@127.0.0.1
-
 CT_READABLE ?= false
 
 compile:
@@ -32,22 +30,22 @@ test: smoke-test ct-consistency ct-fault-tolerance cover
 
 .PHONY: smoke-test
 smoke-test:
-	$(REBAR) do eunit, ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME)
+	$(REBAR) do eunit, ct -v --readable=$(CT_READABLE)
 
 .PHONY: ct-consistency
 ct-consistency:
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite mria_proper_suite,mria_proper_mixed_cluster_suite
+	$(REBAR) ct -v --readable=$(CT_READABLE) --suite mria_proper_suite,mria_proper_mixed_cluster_suite
 
 .PHONY: ct-fault-tolerance
 ct-fault-tolerance:
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite mria_fault_tolerance_suite
+	$(REBAR) ct -v --readable=$(CT_READABLE) --suite mria_fault_tolerance_suite
 
 .PHONY: ct-suite
 ct-suite: compile
 ifneq ($(TESTCASE),)
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --suite $(SUITE)  --case $(TESTCASE)
 else
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --suite $(SUITE)
 endif
 
 cover: | smoke-test ct-consistency ct-fault-tolerance

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps,
- [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.4"}}},
+ [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.5"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.10"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps,
- [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
-  {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
+ [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.4"}}},
+  {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.10"}}}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.0"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-  {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.1"}}},
+  {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.10"}}}
  ]}.
 

--- a/src/mria.erl
+++ b/src/mria.erl
@@ -61,8 +61,6 @@
 
         , create_table/2
         , wait_for_tables/1
-
-        , create_table_internal/3
         ]).
 
 -define(IS_MON_TYPE(T), T == membership orelse T == partition).
@@ -231,51 +229,21 @@ create_table(Name, TabDef) ->
         #{ name    => Name
          , options => TabDef
          }),
-    Storage = proplists:get_value(storage, TabDef, ram_copies),
-    MnesiaTabDef = lists:keydelete(rlog_shard, 1, lists:keydelete(storage, 1, TabDef)),
-    case {proplists:get_value(rlog_shard, TabDef, ?LOCAL_CONTENT_SHARD),
-          proplists:get_value(local_content, TabDef, false)} of
-        {?LOCAL_CONTENT_SHARD, false} ->
-            ?LOG(critical, "Table ~p doesn't belong to any shard", [Name]),
-            error(badarg);
-        {Shard, _LocalContent} ->
-            case create_table_internal(Name, Storage, MnesiaTabDef) of
-                ok ->
-                    %% It's important to add the table to the shard
-                    %% _after_ we actually create it:
-                    Entry = #?schema{ mnesia_table = Name
-                                    , shard        = Shard
-                                    , storage      = Storage
-                                    , config       = MnesiaTabDef
-                                    },
-                    case mria_config:whoami() of
-                        core ->
-                            %% `mria_rlog_server' reacts on the mnesia
-                            %% events for the `mria_schema' table, and
-                            %% triggers the necessary updates
-                            %% asynchronously.However, the process
-                            %% that calls `create_table' expects
-                            %% everything to be ready after the call,
-                            %% so we request the server to handle the
-                            %% schema update synchronoulsy.
-                            mria_rlog_server:schema_update(Entry);
-                        _ ->
-                            %% On the replicant we don't have the same
-                            %% problem, since any operation that may
-                            %% observe stale schema state is routed to
-                            %% the core node.
-                            %%
-                            %% So we just update the schema table
-                            %% directly to let the LB know that it has
-                            %% to take care of the new shard, should
-                            %% the call introduce it, but the rest is
-                            %% handled by the logic inside
-                            %% `mria_rlog:wait_for_shards'.
-                            mria_schema:add_entry(Entry)
-                    end;
-                Err ->
-                    Err
-            end
+    Result = case mria_config:whoami() of
+                 replicant ->
+                     mria_lib:rpc_to_core_node( ?mria_meta_shard
+                                              , mria_schema, create_table
+                                              , [Name, TabDef]
+                                              );
+                 core ->
+                     mria_schema:create_table(Name, TabDef)
+             end,
+    case Result of
+        {atomic, ok} ->
+            mria_schema:ensure_local_table(Name),
+            ok;
+        Err ->
+            Err
     end.
 
 -spec wait_for_tables([table()]) -> ok | {error, _Reason}.
@@ -289,19 +257,6 @@ wait_for_tables(Tables) ->
         Err ->
             Err
     end.
-
-%% @doc Create mnesia table (skip RLOG stuff)
--spec(create_table_internal(table(), storage(), TabDef :: list()) ->
-             ok | {error, any()}).
-create_table_internal(Name, Storage, Params) ->
-    %% Note: it's impossible to check storage type due to possiblity
-    %% of registering custom backends
-    ClusterNodes = case mria_config:role() of
-                       core      -> mnesia:system_info(db_nodes);
-                       replicant -> [node()]
-                   end,
-    TabDef = [{Storage, ClusterNodes}|Params],
-    mria_lib:ensure_tab(mnesia:create_table(Name, TabDef)).
 
 -spec ro_transaction(mria_rlog:shard(), fun(() -> A)) -> t_result(A).
 ro_transaction(?LOCAL_CONTENT_SHARD, Fun) ->

--- a/src/mria.erl
+++ b/src/mria.erl
@@ -235,7 +235,7 @@ create_table(Name, TabDef) ->
                                               , mria_schema, create_table
                                               , [Name, TabDef]
                                               );
-                 core ->
+                 _ ->
                      mria_schema:create_table(Name, TabDef)
              end,
     case Result of

--- a/src/mria_app.erl
+++ b/src/mria_app.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -34,10 +34,6 @@ start(_Type, _Args) ->
     maybe_perform_disaster_recovery(),
     mria_mnesia:ensure_schema(),
     mria_mnesia:ensure_started(),
-    ?tp(notice, "Initializing RLOG schema", #{}),
-    mria_schema:init(),
-    ?tp(notice, "Converging schema", #{}),
-    mria_mnesia:converge_schema(),
     ?tp(notice, "Starting shards", #{}),
     Sup = mria_sup:start_link(),
     ?tp(notice, "Mria is running", #{}),

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -364,10 +364,11 @@ do_rpc_to_core_node(Shard, Module, Function, Args, Retries) ->
 
 -spec find_upstream_node(mria_rlog:shard()) -> node().
 find_upstream_node(Shard) ->
-    case mria_status:get_core_node(Shard, infinity) of
-        {ok, Node} -> Node;
-        timeout    -> error(transaction_timeout)
-    end.
+    ?tp_span(find_upstream_node, #{shard => Shard, tab => ets:tab2list(mria_rlog_status_tab)},
+             case mria_status:get_core_node(Shard, infinity) of
+                 {ok, Node} -> Node;
+                 timeout    -> error(transaction_timeout)
+             end).
 
 ensure_no_transaction() ->
     case mnesia:get_activity_id() of

--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -388,9 +388,9 @@ do_rpc_to_core_node(Shard, Module, Function, Args, Retries) ->
 -spec find_upstream_node(mria_rlog:shard()) -> node().
 find_upstream_node(Shard) ->
     ?tp_span(find_upstream_node, #{shard => Shard},
-             case mria_status:get_core_node(Shard, infinity) of
-                 {ok, Node} -> Node;
-                 timeout    -> error(transaction_timeout)
+             begin
+                 {ok, Node} = mria_status:get_core_node(Shard, infinity),
+                 Node
              end).
 
 ensure_no_transaction() ->

--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -44,6 +44,8 @@
         , exec_callback_async/1
 
         , sup_child_pid/2
+
+        , set_where_to_read/2
         ]).
 
 %% Internal exports
@@ -334,6 +336,23 @@ with_middleman(Mod, Fun, Args) ->
             end
     end.
 
+%% @private Dirty hack: patch mnesia internal table (see
+%% implementation of `mnesia:dirty_rpc')
+-spec set_where_to_read(node(), mria:table()) -> boolean().
+set_where_to_read(Node, Table) ->
+    Key = {Table, where_to_read},
+    case ets:lookup(mnesia_gvar, Key) of
+        [{Key, OldNode}] ->
+            %% Sanity check (Hopefully it breaks if something inside
+            %% mnesia changes):
+            true = is_atom(OldNode),
+            %% Now change it:
+            ets:insert(mnesia_gvar, {Key, Node}),
+            true;
+        [] ->
+            false
+    end.
+
 %%================================================================================
 %% Internal
 %%================================================================================
@@ -364,7 +383,7 @@ do_rpc_to_core_node(Shard, Module, Function, Args, Retries) ->
 
 -spec find_upstream_node(mria_rlog:shard()) -> node().
 find_upstream_node(Shard) ->
-    ?tp_span(find_upstream_node, #{shard => Shard, tab => ets:tab2list(mria_rlog_status_tab)},
+    ?tp_span(find_upstream_node, #{shard => Shard},
              case mria_status:get_core_node(Shard, infinity) of
                  {ok, Node} -> Node;
                  timeout    -> error(transaction_timeout)

--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -348,6 +348,10 @@ set_where_to_read(Node, Table) ->
             true = is_atom(OldNode),
             %% Now change it:
             ets:insert(mnesia_gvar, {Key, Node}),
+            ?tp(rlog_read_from,
+                #{ source => Node
+                 , table  => Table
+                 }),
             true;
         [] ->
             false

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,14 +23,11 @@
 
 -include("mria.hrl").
 -include("mria_rlog.hrl").
--include_lib("kernel/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 
 %% Start and stop mnesia
 -export([ %% TODO: remove it
-          converge_schema/0
-
-        , ensure_started/0
+          ensure_started/0
         , ensure_stopped/0
         , connect/1
         ]).
@@ -266,16 +263,6 @@ copy_schema(Node) ->
             ok;
         {aborted, Error} ->
             {error, Error}
-    end.
-
-%% @private
-%% @doc Init mnesia tables.
-converge_schema() ->
-    case mria_schema:create_table_type() of
-        create ->
-            ok;
-        copy ->
-            mria_schema:converge_core()
     end.
 
 %% @doc Copy mnesia table.

--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -101,10 +101,10 @@ handle_cast(Cast, St) ->
     ?unexpected_event_tp(#{cast => Cast, state => St}),
     {noreply, St}.
 
-terminate(Reason, #s{shard = Shard, seqno = SeqNo}) ->
-    ?tp(mria_replica_importer_worker_stop, #{ shard => Shard
-                                            , seqno => SeqNo
-                                            , reason => Reason
+terminate(_Reason, #s{shard = _Shard, seqno = _SeqNo}) ->
+    ?tp(mria_replica_importer_worker_stop, #{ shard => _Shard
+                                            , seqno => _SeqNo
+                                            , reason => _Reason
                                             }).
 
 %%================================================================================

--- a/src/mria_replicant_shard_sup.erl
+++ b/src/mria_replicant_shard_sup.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -58,21 +58,24 @@ start_bootstrap_client(SupPid, Shard, RemoteNode, ReplicaPid) ->
 %%================================================================================
 
 init(Shard) ->
-    SupFlags = #{ strategy  => one_for_all
-                , intensity => 0
-                , period    => 1
+    SupFlags = #{ strategy      => one_for_all
+                , intensity     => 0
+                , period        => 1
+                , auto_shutdown => any_significant
                 },
-    Children = [ #{ id       => importer_worker
-                  , start    => {mria_replica_importer_worker, start_link, [Shard]}
-                  , restart  => permanent
-                  , type     => worker
-                  , shutdown => 1000
+    Children = [ #{ id          => importer_worker
+                  , start       => {mria_replica_importer_worker, start_link, [Shard]}
+                  , restart     => transient
+                  , significant => true
+                  , type        => worker
+                  , shutdown    => 1000
                   }
-               , #{ id       => replica
-                  , start    => {mria_rlog_replica, start_link, [self(), Shard]}
-                  , restart  => permanent
-                  , shutdown => 1000
-                  , type     => worker
+               , #{ id          => replica
+                  , start       => {mria_rlog_replica, start_link, [self(), Shard]}
+                  , restart     => transient
+                  , significant => true
+                  , shutdown    => 1000
+                  , type        => worker
                   }
                ],
     {ok, {SupFlags, Children}}.

--- a/src/mria_rlog.erl
+++ b/src/mria_rlog.erl
@@ -170,7 +170,12 @@ subscribe(Shard, RemoteNode, Subscriber, Checkpoint) ->
 -spec get_protocol_version() -> integer().
 get_protocol_version() ->
     %% Should be increased on incompatible changes:
-    0.
+    %%
+    %% Changelog:
+    %%
+    %% 0 -> 1: Add clear_table message to the batch message of the
+    %% boostrapper.
+    1.
 
 intercept_trans(Tid, Commit) ->
     ?tp(mria_rlog_intercept_trans, Commit#{tid => Tid}),

--- a/src/mria_rlog.erl
+++ b/src/mria_rlog.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
         , init/0
 
         , intercept_trans/2
+        , ensure_shard/1
         ]).
 
 -export_type([ shard/0

--- a/src/mria_rlog.hrl
+++ b/src/mria_rlog.hrl
@@ -1,6 +1,7 @@
 -ifndef(MRIA_RLOG_HRL).
 -define(MRIA_RLOG_HRL, true).
 
+-define(mria_meta_shard, '$mria_meta_shard').
 -define(schema, mria_schema).
 
 %% Note to self: don't forget to update all the match specs in

--- a/src/mria_rlog.hrl
+++ b/src/mria_rlog.hrl
@@ -19,6 +19,13 @@
 
 -define(IS_TRANS(TID), (element(1, (TID)) =:= tid)).
 
+-define(unexpected_event_kind, "Mria worker received unexpected event").
+-define(unexpected_event_tp(Params),
+        ?tp(warning, ?unexpected_event_kind,
+            Params#{ process => ?MODULE
+                   , callback => ?FUNCTION_NAME
+                   })).
+
 %% Messages
 
 -record(entry,

--- a/src/mria_rlog_agent.erl
+++ b/src/mria_rlog_agent.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_rlog_agent.erl
+++ b/src/mria_rlog_agent.erl
@@ -138,12 +138,11 @@ handle_stop(_State, From, _Data) ->
     {stop_and_reply, normal, {reply, From, ok}}.
 
 handle_unknown(EventType, Event, State, Data) ->
-    ?tp(warning, "rlog agent received unknown event",
-        #{ event_type => EventType
-         , event => Event
-         , state => State
-         , data => Data
-         }),
+    ?unexpected_event_tp(#{ event_type => EventType
+                          , event => Event
+                          , state => State
+                          , data => Data
+                          }),
     keep_state_and_data.
 
 handle_state_trans(_OldState, _State, _Data) ->

--- a/src/mria_rlog_replica.erl
+++ b/src/mria_rlog_replica.erl
@@ -111,7 +111,7 @@ handle_event(info, #imported{ref = Ref}, State, D = #d{importer_ref = Ref}) ->
 handle_event(enter, OldState, ?disconnected, D) ->
     handle_state_trans(OldState, ?disconnected, D),
     initiate_reconnect(D);
-handle_event(timeout, ?reconnect, ?disconnected, D) ->
+handle_event(state_timeout, ?reconnect, ?disconnected, D) ->
     handle_reconnect(D);
 %% Events specific to `bootstrap' state:
 handle_event(enter, OldState, ?bootstrap, D) ->
@@ -306,7 +306,7 @@ handle_importer_ack(State, D0 = #d{replayq = Q, shard = Shard}) ->
 -spec initiate_reconnect(data()) -> fsm_result().
 initiate_reconnect(#d{shard = Shard}) ->
     mria_status:notify_shard_down(Shard),
-    {keep_state_and_data, [{timeout, 0, ?reconnect}]}.
+    {keep_state_and_data, [{state_timeout, 0, ?reconnect}]}.
 
 %% @private Try connecting to a core node
 -spec handle_reconnect(data()) -> fsm_result().
@@ -340,7 +340,7 @@ handle_reconnect(#d{shard = Shard, checkpoint = Checkpoint, parent_sup = ParentS
                 #{ reason => Err
                  }),
             ReconnectTimeout = application:get_env(mria, rlog_replica_reconnect_interval, 5000),
-            {keep_state_and_data, [{timeout, ReconnectTimeout, ?reconnect}]}
+            {keep_state_and_data, [{state_timeout, ReconnectTimeout, ?reconnect}]}
     end.
 
 -spec try_connect(mria_rlog:shard(), mria_rlog_server:checkpoint()) ->

--- a/src/mria_rlog_replica.erl
+++ b/src/mria_rlog_replica.erl
@@ -137,9 +137,9 @@ handle_event(EventType, Event, State, Data) ->
 code_change(_OldVsn, State, Data, _Extra) ->
     {ok, State, Data}.
 
-terminate(Reason, _State, Data) ->
+terminate(_Reason, _State, Data) ->
     close_replayq(Data),
-    ?tp(stopping_rlog_shard, #{shard => Data#d.shard, reason => Reason}),
+    ?tp(stopping_rlog_shard, #{shard => Data#d.shard, reason => _Reason}),
     ok.
 
 format_status(Status) ->
@@ -457,10 +457,7 @@ format_data(D) ->
 -spec set_where_to_read(mria_rlog:shard(), node()) -> ok.
 set_where_to_read(Shard, Node) ->
     [mria_lib:set_where_to_read(Node, Tab) || Tab <- mria_schema:tables_of_shard(Shard)],
-    ?tp(rlog_read_from,
-        #{ source => Node
-         , shard  => Shard
-         }).
+    ok.
 
 close_replayq(D = #d{replayq = RQ}) ->
     case RQ of

--- a/src/mria_rlog_server.erl
+++ b/src/mria_rlog_server.erl
@@ -171,12 +171,11 @@ handle_info({trans, Tid, CommitRecord}, St0) ->
     St = St0#s{seqno = SeqNo + 1},
     {noreply, St};
 handle_info(Info, St) ->
-    ?tp(warning, "Received unknown event",
-        #{ info => Info
-         }),
+    ?unexpected_event_tp(#{info => Info, state => St}),
     {noreply, St}.
 
-handle_cast(_Cast, St) ->
+handle_cast(Cast, St) ->
+    ?unexpected_event_tp(#{cast => Cast, state => St}),
     {noreply, St}.
 
 handle_call({subscribe, Subscriber, Checkpoint}, _From, State0) ->
@@ -205,8 +204,9 @@ handle_call(probe, _From, State) ->
     {reply, true, State};
 handle_call({schema_update, Entry}, _From, State) ->
     {reply, ok, handle_schema_update(Entry, State)};
-handle_call(Call, _From, St) ->
-    {reply, {error, {unknown_call, Call}}, St}.
+handle_call(Call, From, St) ->
+    ?unexpected_event_tp(#{call => Call, from => From, state => St}),
+    {reply, {error, unknown_call}, St}.
 
 terminate(_Reason, St) ->
     {ok, St}.

--- a/src/mria_rlog_server.erl
+++ b/src/mria_rlog_server.erl
@@ -63,7 +63,6 @@
         , bootstrap_threshold :: integer()
         , agents = []         :: [pid()]
         , seqno  = 0          :: integer()
-        , schema              :: [mria_schema:entry()]
         }).
 
 %%================================================================================
@@ -110,8 +109,10 @@ dispatch(Shard, Tid, Commit) ->
 
 -spec schema_update(mria_schema:entry()) -> ok.
 schema_update(Entry = #?schema{shard = Shard}) ->
-    case mria_config:whoami() of
-        core ->
+    case {mria_config:whoami(), Shard} of
+        {_, ?LOCAL_CONTENT_SHARD} ->
+            ok;
+        {core, _} ->
             ok = mria_rlog:ensure_shard(Shard),
             gen_server:call(Shard, {schema_update, Entry});
         _ ->
@@ -132,8 +133,28 @@ init({Parent, Shard}) ->
     ?tp(rlog_server_start, #{node => node()}),
     {ok, {Parent, Shard}, {continue, post_init}}.
 
-handle_info({mnesia_table_event, {write, Record, ActivityId}}, St) ->
-    handle_mnesia_event(Record, ActivityId, St);
+handle_continue(post_init, {Parent, Shard}) ->
+    Tables = process_schema(Shard),
+    AgentSup = mria_core_shard_sup:start_agent_sup(Parent, Shard),
+    BootstrapperSup = mria_core_shard_sup:start_bootstrapper_sup(Parent, Shard),
+    mria_mnesia:wait_for_tables(Tables),
+    mria_schema:subscribe_to_shard_schema_updates(Shard),
+    mria_status:notify_shard_up(Shard, self()),
+    ?tp(notice, "Shard fully up",
+        #{ node  => node()
+         , shard => Shard
+         }),
+    State = #s{ shard               = Shard
+              , parent_sup          = Parent
+              , agent_sup           = AgentSup
+              , bootstrapper_sup    = BootstrapperSup
+              , tlog_replay         = 30 %% TODO: unused. Remove?
+              , bootstrap_threshold = 3000 %% TODO: unused. Remove?
+              },
+    {noreply, State}.
+
+handle_info({schema_event, _, {new_table, _Shard, Entry}}, St) ->
+    handle_schema_update(Entry, St);
 handle_info({'DOWN', _MRef, process, Pid, _Info}, St0 = #s{agents = Agents}) ->
     mria_status:notify_agent_disconnect(Pid),
     St = St0#s{agents = lists:delete(Pid, Agents)},
@@ -154,27 +175,6 @@ handle_info(Info, St) ->
         #{ info => Info
          }),
     {noreply, St}.
-
-handle_continue(post_init, {Parent, Shard}) ->
-    Tables = process_schema(Shard),
-    mria_config:load_shard_config(Shard, Tables),
-    AgentSup = mria_core_shard_sup:start_agent_sup(Parent, Shard),
-    BootstrapperSup = mria_core_shard_sup:start_bootstrapper_sup(Parent, Shard),
-    mria_mnesia:wait_for_tables(Tables),
-    mria_status:notify_shard_up(Shard, self()),
-    ?tp(notice, "Shard fully up",
-        #{ node  => node()
-         , shard => Shard
-         }),
-    State = #s{ shard               = Shard
-              , parent_sup          = Parent
-              , agent_sup           = AgentSup
-              , bootstrapper_sup    = BootstrapperSup
-              , tlog_replay         = 30 %% TODO: unused. Remove?
-              , bootstrap_threshold = 3000 %% TODO: unused. Remove?
-              , schema              = mria_schema:table_specs_of_shard(Shard)
-              },
-    {noreply, State}.
 
 handle_cast(_Cast, St) ->
     {noreply, St}.
@@ -242,51 +242,25 @@ maybe_start_child(Supervisor, Args) ->
 -spec process_schema(mria_rlog:shard()) -> [mria:table()].
 process_schema(Shard) ->
     ok = mria_mnesia:wait_for_tables([?schema]),
-    {ok, _} = mnesia:subscribe({table, ?schema, simple}),
-    Tables = mria_schema:tables_of_shard(Shard),
-    Tables.
+    mria_schema:tables_of_shard(Shard).
 
--spec handle_schema_update(mria_schema:entry(), #s{}) -> #s{}.
-handle_schema_update( Entry = #?schema{shard = Shard, mnesia_table = Tab}
-                    , #s{shard = Shard, parent_sup = Parent, schema = OldSchema} = St0
+-spec handle_schema_update(mria_schema:entry(), #s{}) -> {noreply, #s{}}.
+handle_schema_update( #?schema{shard = Shard, mnesia_table = Tab}
+                    , #s{shard = Shard, parent_sup = Parent} = St0
                     ) ->
-    ok = mria_schema:add_entry(Entry),
-    case lists:keyfind(Tab, #?schema.mnesia_table, OldSchema) of
-        Entry -> % unchanged
-            St0;
-        _ ->
-            ?tp(notice, "Shard schema change",
-                #{ shard => Shard
-                 , table => Tab
-                 }),
-            Tables = mria_schema:tables_of_shard(Shard),
-            mria_config:load_shard_config(Shard, Tables),
-            %% Shut down all the downstream connections by restarting the supervisors:
-            AgentSup = mria_core_shard_sup:restart_agent_sup(Parent),
-            BootstrapperSup = mria_core_shard_sup:restart_bootstrapper_sup(Parent),
-            Schema = lists:keystore(Tab, #?schema.mnesia_table, OldSchema, Entry),
-            St0#s{ agent_sup        = AgentSup
-                 , bootstrapper_sup = BootstrapperSup
-                 , schema           = Schema
-                 }
-    end;
-handle_schema_update(_, St) ->
-    %% Table belongs to some other shard, nothing to see here.
-    St.
-
-handle_mnesia_event(Entry = #?schema{mnesia_table = NewTab, shard = ChangedShard}, ActivityId, St) ->
-    #s{shard = Shard} = St,
-    case ChangedShard of
-        Shard ->
-            ?tp(debug, rlog_server_table_event,
-                #{ shard       => Shard
-                 , new_table   => NewTab
-                 , activity_id => ActivityId
-                 }),
-            {noreply, handle_schema_update(Entry, St)};
-        _ ->
-            {noreply, St}
-    end.
+    ?tp(notice, "Shard schema change",
+        #{ shard => Shard
+         , new_table => Tab
+         }),
+    %% Shut down all the downstream connections by restarting the supervisors:
+    AgentSup = mria_core_shard_sup:restart_agent_sup(Parent),
+    BootstrapperSup = mria_core_shard_sup:restart_bootstrapper_sup(Parent),
+    {noreply, St0#s{ agent_sup        = AgentSup
+                   , bootstrapper_sup = BootstrapperSup
+                   }};
+handle_schema_update(_, S) ->
+    %% Should not happen
+    {noreply, S}.
 
 -spec transform_commit(mria_mnesia:tid(), mria_mnesia:commit_records()) ->
           mria_rlog:tx().

--- a/src/mria_rlog_sup.erl
+++ b/src/mria_rlog_sup.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -44,27 +44,19 @@ init(core) ->
                 , intensity => 1
                 , period => 1
                 },
-    Children = [status_mgr(), child_sup()],
+    Children = [child_sup()],
     {ok, {SupFlags, Children}};
 init(replicant) ->
     SupFlags = #{ strategy => one_for_all
                 , intensity => 1
                 , period => 1
                 },
-    Children = [status_mgr(), core_node_lb(), child_sup()],
+    Children = [core_node_lb(), child_sup()],
     {ok, {SupFlags, Children}}.
 
 %%================================================================================
 %% Internal functions
 %%================================================================================
-
-status_mgr() ->
-    #{ id => mria_status
-     , start => {mria_status, start_link, []}
-     , restart => permanent
-     , shutdown => 5000
-     , type => worker
-     }.
 
 core_node_lb() ->
     #{ id => mria_lb

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -14,21 +14,35 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
-%% Functions related to the management of the RLOG schema
+%% Functions related to the management and synchronization of the mria
+%% schema.
+%%
+%% This server serializes all schema operations on a local node
+%% (effectively it means that all `mria:create_table' calls are
+%% executed sequentially. Not a big deal since we don't expect this to
+%% be a hotspot).
 -module(mria_schema).
 
+-behaviour(gen_server).
+
 %% API:
--export([ init/0
-        , add_entry/1
+-export([ create_table/2
+        , subscribe_to_shard_schema_updates/1
+        , ensure_local_table/1
+
         , tables_of_shard/1
         , shard_of_table/1
         , table_specs_of_shard/1
         , shards/0
 
-        , converge_replicant/2
-        , converge_core/0
+        , start_link/0
+        ]).
 
-        , create_table_type/0
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
         ]).
 
 -include("mria_rlog.hrl").
@@ -41,7 +55,16 @@
                 , config       :: list()
                 }.
 
--export_type([entry/0]).
+-type subscribers() :: #{mria_rlog:shard() => [pid()]}.
+
+-type event() :: {schema_event, subscription(),
+                  {new_table, mria_rlog:shard(), entry()}}.
+
+-opaque subscription() :: pid().
+
+-define(SERVER, ?MODULE).
+
+-export_type([entry/0, subscription/0, event/0]).
 
 %% WARNING: Treatment of the schema table is different on the core
 %% nodes and replicants. Schema transactions on core nodes are
@@ -51,7 +74,7 @@
 %% inconsistent with the core nodes' view.
 %%
 %% Therefore one should be rather careful with the contents of the
-%% rlog_schema table.
+%% `?schema' table.
 
 %%================================================================================
 %% Type declarations
@@ -61,7 +84,9 @@
 %% API
 %%================================================================================
 
-%% @doc Add a table to the shard
+%% @private Add a table to the shard. Warning: table may not be ready
+%% for the writes after this function returns. One should wait for it
+%% using `mria_schema:ensure_local_table/1'
 %%
 %% Note: currently it's the only schema operation that we support. No
 %% removal and no handover of the table between the shards is
@@ -90,40 +115,39 @@
 %%
 %% Currently there is no requirement to implement this, so we can get
 %% away with managing each shard separately
--spec add_entry(mria_schema:entry()) -> ok.
-add_entry(TabDef) ->
-    case mnesia:transaction(fun do_add_table/1, [TabDef], infinity) of
-        {atomic, ok}   -> ok;
-        {aborted, Err} -> error({bad_schema, Err, TabDef})
-    end.
+-spec create_table(mria:table(), _Properties :: list()) -> mria:t_result(ok).
+create_table(Table, TabDef) ->
+    core = mria_config:role(), % assert
+    gen_server:call(?MODULE, {create_table, Table, TabDef}, infinity).
 
-%% @doc Create the internal schema table if needed
-init() ->
-    ?tp(debug, rlog_schema_init, #{}),
-    ok = mria:create_table_internal(?schema, ram_copies,
-                                    [{type, ordered_set},
-                                     {record_name, ?schema},
-                                     {attributes, record_info(fields, ?schema)}
-                                    ]),
-    ok = mria_mnesia:copy_table(?schema, ram_copies),
-    mria_mnesia:wait_for_tables([?schema]),
-    ok.
+%% @private Return the list of tables that belong to the shard and their
+%% properties:
+-spec table_specs_of_shard(mria_rlog:shard()) -> [mria_schema:entry()].
+table_specs_of_shard(Shard) ->
+    Pattern = #?schema{mnesia_table = '_', shard = Shard, storage = '_', config = '_'},
+    {atomic, Result} = mnesia:transaction(fun mnesia:match_object/1, [Pattern]),
+    Result.
 
-%% @doc Return the list of tables that belong to the shard.
+%% @private Return the list of tables that belong to the shard.
 -spec tables_of_shard(mria_rlog:shard()) -> [mria:table()].
 tables_of_shard(Shard) ->
     [Tab || #?schema{mnesia_table = Tab} <- table_specs_of_shard(Shard)].
 
-%% @doc Return the list of tables that belong to the shard and their
-%% properties:
--spec table_specs_of_shard(mria_rlog:shard()) -> [mria_schema:entry()].
-table_specs_of_shard(Shard) ->
-    %%core = mria_config:role(), % assert
-    Pattern = #?schema{mnesia_table = '_', shard = Shard, storage = '_', config = '_'},
-    {atomic, Tuples} = mnesia:transaction(fun mnesia:match_object/1, [Pattern], infinity),
-    Tuples.
+%% @private Subscribe to the schema events
+%%
+%% The subscriber will get events of type `event()' every time a new
+%% table is added to the shard.
+-spec subscribe_to_shard_schema_updates(mria_rlog:shard()) -> {ok, subscription()}.
+subscribe_to_shard_schema_updates(Shard) ->
+    gen_server:call(?SERVER, {subscribe_to_shard_schema_updates, Shard, self()}).
 
-%% @doc Get the shard of a table
+%% @private Ensure the local mnesia table is ready to accept writes
+-spec ensure_local_table(mria:table()) -> true.
+ensure_local_table(Table) ->
+    ?tp_span(debug, ?FUNCTION_NAME, #{table => Table},
+             mria_status:local_table_present(Table)).
+
+%% @private Get the shard of a table
 -spec shard_of_table(mria:table()) -> {ok, mria_rlog:shard()} | undefined.
 shard_of_table(Table) ->
     case mnesia:dirty_read(?schema, Table) of
@@ -133,70 +157,196 @@ shard_of_table(Table) ->
             undefined
     end.
 
-%% @doc Return the list of known shards
+%% @private Return the list of known shards
 -spec shards() -> [mria_rlog:shard()].
 shards() ->
     MS = {#?schema{mnesia_table = '_', shard = '$1', config = '_', storage = '_'}, [], ['$1']},
     {atomic, Shards} = mnesia:transaction(fun mnesia:select/2, [?schema, [MS]], infinity),
     lists:usort(Shards).
 
-%% @doc Ensure that a core node that freshly joined the cluster has
-%% copies of all the tables
--spec converge_core() -> ok.
-converge_core() ->
-    %% Assert that we've already joined the cluster, and the rest of
-    %% the nodes know about us, so when any of them calls
-    %% `create_table', they add us in the list:
-    DbNodes = [_, _ | _] = mnesia:system_info(db_nodes), % assert
-    true = lists:member(node(), DbNodes),
-    ?tp(info, "Converging RLOG schema", #{}),
-    TabDefs = ets:tab2list(?schema),
-    lists:foreach(fun ensure_table_copy/1, TabDefs).
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
+%%================================================================================
+%% gen_server callbacks
+%%================================================================================
 
-%% @doc Ensure that the replicant has the same tables as the upstream
--spec converge_replicant(mria_rlog:shard(), [mria_schema:entry()]) -> ok.
-converge_replicant(_Shard, TableSpecs) ->
-    %% TODO: Check shard
-    lists:foreach(fun ensure_table/1, TableSpecs).
+-record(s,
+        { %% We cache the contents of the schema in the process state to notify the local
+          %% processes about the schema updates. Note that we cannot
+          %% simply use the `?schema' table for it: it can be updated
+          %% remotely at unpredicatable time
+          specs :: [entry()]
+        , subscribers = #{} :: subscribers()
+        }).
 
-%% @doc How to create mnesia tables on the node?
--spec create_table_type() -> create | copy.
-create_table_type() ->
-    IsAlone = case mnesia:system_info(extra_db_nodes) of
-                  []    -> true;
-                  [_|_] -> false
-              end,
-    case (mria_rlog:role() =:= replicant) orelse IsAlone of
-        true  -> create;
-        false -> copy
-    end.
+init([]) ->
+    logger:set_process_metadata(#{domain => [mria, rlog, schema]}),
+    ?tp(debug, rlog_schema_init, #{}),
+    State0 = boostrap(),
+    {ok, _} = mnesia:subscribe({table, ?schema, simple}),
+    %% Recreate all the known tables:
+    ?tp(notice, "Converging schema", #{}),
+    Specs = table_specs_of_shard('_'),
+    State = converge_schema(Specs, State0),
+    {ok, State}.
+
+handle_call({subscribe_to_shard_schema_updates, Shard, Pid}, _From, State0 = #s{subscribers = Subs0}) ->
+    Pids = [Pid | maps:get(Shard, Subs0, [])],
+    State = State0#s{subscribers = Subs0#{Shard => Pids}},
+    {reply, {ok, self()}, State};
+handle_call({create_table, Table, TabDef}, _From, State) ->
+    {reply, do_create_table(Table, TabDef), State};
+handle_call(_Call, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info({mnesia_table_event, {write, Entry = #?schema{}, ActivityId}}, State0) ->
+    ?tp(mria_schema_apply_schema_op, #{entry => Entry, activity_id => ActivityId}),
+    {noreply, apply_schema_op(Entry, State0)};
+handle_info(_Info, State) ->
+    {noreply, State}.
 
 %%================================================================================
 %% Internal functions
 %%================================================================================
 
--spec do_add_table(mria_schema:entry()) -> ok.
-do_add_table(TabDef = #?schema{shard = Shard, mnesia_table = Table}) ->
-    case mnesia:wread({?schema, Table}) of
-        [] ->
-            ?tp(info, "Adding table to a shard",
-                #{ shard => Shard
-                 , table => Table
-                 }),
-            mnesia:write(TabDef),
-            ok;
-        [#?schema{shard = Shard}] ->
-            %% We're just being idempotent here:
-            ok;
-        _ ->
-            error(bad_schema)
+-spec do_create_table(mria:table(), list()) -> mria:t_result(ok).
+do_create_table(Table, TabDef) ->
+    case make_entry(Table, TabDef) of
+        {ok, Entry} ->
+            case create_table(Entry) of
+                ok ->
+                    add_entry(Entry);
+                Err ->
+                    {aborted, Err}
+            end;
+        {error, Err} ->
+            {aborted, Err}
     end.
 
--spec ensure_table(mria_schema:entry()) -> ok.
-ensure_table(#?schema{mnesia_table = Table, storage = Storage, config = Config}) ->
-    ok = mria:create_table_internal(Table, Storage, Config).
+-spec add_entry(entry()) -> mria:t_result(ok).
+add_entry(Entry) ->
+    core = mria_config:role(), %% assert
+    mnesia:transaction(
+      fun() ->
+              #?schema{ mnesia_table = Table
+                      , shard        = Shard
+                      } = Entry,
+              case mnesia:wread({?schema, Table}) of
+                  [] ->
+                      ?tp(info, "Adding table to a shard",
+                          #{ shard => Shard
+                           , table => Table
+                           }),
+                      mnesia:write(?schema, Entry, write),
+                      ok;
+                  [#?schema{shard = Shard}] ->
+                      ok;
+                  Prev ->
+                      %% We already have the definition of the table and
+                      %% it's incompatible with the new one (changed
+                      %% shard)
+                      Info = #{ reason => incompatible_schema
+                              , shard => Shard
+                              , table => Table
+                              , new_spec => Entry
+                              , prev_spec => Prev
+                              },
+                      mnesia:abort(Info)
+              end
+      end).
 
--spec ensure_table_copy(mria_schema:entry()) -> ok.
-ensure_table_copy(#?schema{mnesia_table = Table, storage = Storage}) ->
-    mria_mnesia:copy_table(Table, Storage).
+-spec make_entry(mria:table(), _Properties :: list()) -> {ok, entry()} | {error, map()}.
+make_entry(Table, TabDef) ->
+    Storage = proplists:get_value(storage, TabDef, ram_copies),
+    Options = lists:filter(fun({Key, _}) ->
+                                   not lists:member(Key,
+                                                    [ ram_copies, disc_copies, disc_only_copies
+                                                    , rocksdb_copies, storage, rlog_shard
+                                                    ]);
+                             (_) ->
+                                  true
+                           end,
+                           TabDef),
+    case {proplists:get_value(rlog_shard, TabDef, ?LOCAL_CONTENT_SHARD),
+          proplists:get_value(local_content, TabDef, false)} of
+        {?LOCAL_CONTENT_SHARD, false} ->
+            {error, #{ reason => missing_shard
+                     , table => Table
+                     }};
+        {Shard, _} ->
+            {ok, #?schema{ mnesia_table = Table
+                         , shard        = Shard
+                         , storage      = Storage
+                         , config       = Options
+                         }}
+    end.
+
+%%%%% Mnesia schema initialization at the startup
+
+%% @private Init mnesia tables.
+-spec converge_schema([entry()], #s{}) -> #s{}.
+converge_schema(Entries, InitialState) ->
+    lists:foldl(fun apply_schema_op/2, InitialState, Entries).
+
+%% @private Create schema of the schema table and the meta shard. This
+%% is needed so we can replicate schema updates just like regular
+%% transactions.
+boostrap() ->
+    Storage = ram_copies,
+    Opts = [{type, ordered_set},
+            {record_name, ?schema},
+            {attributes, record_info(fields, ?schema)}
+           ],
+    MetaSpec = #?schema{ mnesia_table = ?schema
+                       , shard = ?mria_meta_shard
+                       , storage = Storage
+                       , config = Opts
+                       },
+    %% Create (or copy) the mnesia table and wait for it:
+    ok = create_table(MetaSpec),
+    ok = mria_mnesia:copy_table(?schema, Storage),
+    mria_mnesia:wait_for_tables([?schema]),
+    %% Seed the table with the metadata:
+    {atomic, _} = mnesia:transaction(fun mnesia:write/3, [?schema, MetaSpec, write], infinity),
+    apply_schema_op(MetaSpec, #s{specs = []}).
+
+%%%%% Handling of the online schema updates
+
+-spec apply_schema_op(entry(), #s{}) -> #s{}.
+apply_schema_op( #?schema{mnesia_table = Table, storage = Storage, shard = Shard} = Entry
+               , #s{specs = OldEntries, subscribers = Subscribers} = State
+               ) ->
+    case lists:keyfind(Table, #?schema.mnesia_table, OldEntries) of
+        false -> % new entry
+            Ret = case mria_rlog:role() of
+                      core ->
+                          mria_lib:ensure_ok(mria_mnesia:copy_table(Table, Storage));
+                      replicant ->
+                          create_table(Entry)
+                  end,
+            ok = Ret, %% TODO: print an error message under some conditions?
+            Tables = tables_of_shard(Shard),
+            mria_config:load_shard_config(Shard, Tables),
+            mria_status:notify_local_table(Table),
+            notify_change(Shard, Entry, Subscribers),
+            State#s{specs = [Entry|OldEntries]};
+        _CachedEntry ->
+            State
+    end.
+
+-spec notify_change(mria_rlog:shard(), entry(), subscribers()) -> ok.
+notify_change(Shard, Entry, Subscribers) ->
+    Pids = maps:get(Shard, Subscribers, []),
+    [Pid ! {schema_event, self(),
+            {new_table, Shard, Entry}} || Pid <- Pids],
+    ok.
+
+%% @doc Try to create a mnesia table according to the spec
+-spec create_table(entry()) -> ok | _.
+create_table(#?schema{mnesia_table = Table, storage = Storage, config = Config}) ->
+    mria_lib:ensure_tab(mnesia:create_table(Table, [{Storage, [node()]} | Config])).

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -208,8 +208,8 @@ handle_cast(Cast, State) ->
 
 handle_info({mnesia_table_event, Event}, State0) ->
     case Event of
-        {write, Entry = #?schema{}, ActivityId} ->
-            ?tp(mria_schema_apply_schema_op, #{entry => Entry, activity_id => ActivityId}),
+        {write, Entry = #?schema{}, _ActivityId} ->
+            ?tp(mria_schema_apply_schema_op, #{entry => Entry, activity_id => _ActivityId}),
             {noreply, apply_schema_op(Entry, State0)};
         _SchemaEvent ->
             {noreply, State0}

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -180,11 +180,9 @@ create_table_type() ->
 do_add_table(TabDef = #?schema{shard = Shard, mnesia_table = Table}) ->
     case mnesia:wread({?schema, Table}) of
         [] ->
-            IsLive = Shard =/= ?LOCAL_CONTENT_SHARD andalso is_pid(whereis(Shard)),
             ?tp(info, "Adding table to a shard",
                 #{ shard => Shard
                  , table => Table
-                 , live_change => IsLive
                  }),
             mnesia:write(TabDef),
             ok;

--- a/src/mria_shards_sup.erl
+++ b/src/mria_shards_sup.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_shards_sup.erl
+++ b/src/mria_shards_sup.erl
@@ -66,7 +66,7 @@ init([Shards]) ->
                 , intensity => 100
                 , period    => 1
                 },
-    Children = lists:map(fun shard_sup/1, Shards),
+    Children = lists:map(fun shard_sup/1, [?mria_meta_shard|Shards]),
     {ok, {SupFlags, Children}}.
 
 %%================================================================================

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,6 +38,9 @@
          notify_replicant_bootstrap_start/1, notify_replicant_bootstrap_complete/1,
          notify_replicant_bootstrap_import/1,
 
+         local_table_present/1,
+         notify_local_table/1,
+
          notify_agent_connect/3, notify_agent_disconnect/2, notify_agent_disconnect/1
         ]).
 
@@ -65,6 +68,7 @@
 -define(replicant_bootstrap_complete, replicant_bootstrap_complete).
 -define(replicant_bootstrap_import, replicant_bootstrap_import).
 -define(agent_pid, agent_pid).
+-define(local_table, local_table).
 
 %%================================================================================
 %% API funcions
@@ -286,6 +290,14 @@ notify_replicant_bootstrap_import(Shard) ->
     Op = {2, 1},
     ets:update_counter(?stats_tab, Key, Op, {Key, 0}),
     ok.
+
+-spec notify_local_table(mria:table()) -> ok.
+notify_local_table(Table) ->
+    do_notify_up(?local_table, Table, true).
+
+-spec local_table_present(mria:table()) -> true.
+local_table_present(Table) ->
+    mria_condition_var:read({?local_table, Table}).
 
 %%================================================================================
 %% gen_server callbacks:

--- a/src/mria_sup.erl
+++ b/src/mria_sup.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_sup.erl
+++ b/src/mria_sup.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -38,7 +38,9 @@ init(mnesia) ->
            , intensity => 0
            , period => 3600
            },
-          [child(mria_membership, worker),
+          [child(mria_status, worker),
+           child(mria_schema, worker),
+           child(mria_membership, worker),
            child(mria_node_monitor, worker)
           ]}};
 init(rlog) ->
@@ -46,7 +48,9 @@ init(rlog) ->
            , intensity => 0
            , period => 3600
            },
-          [child(mria_membership, worker),
+          [child(mria_status, worker),
+           child(mria_schema, worker),
+           child(mria_membership, worker),
            child(mria_node_monitor, worker),
            child(mria_rlog_sup, supervisor)
           ]}}.

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -98,6 +98,7 @@ t_bootstrap(_) ->
     Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),
     NRecords = 4321,
     ?check_trace(
+                                                %#{timetrap => 30_000},
         try
             Nodes = [Core, Replicant] = mria_ct:start_cluster(mria, Cluster),
             mria_mnesia_test_util:stabilize(1000),
@@ -716,7 +717,7 @@ t_rlog_schema(_) ->
                                        [tab1, [{rlog_shard, test_shard}]])
                        ),
            %% Try to change the shard of an existing table (this should crash):
-           ?assertMatch( {[{badrpc, {'EXIT', _}}, {badrpc, {'EXIT', _}}], []}
+           ?assertMatch( {[{aborted, _}, {aborted, _}], []}
                        , rpc:multicall([N1, N2], mria, create_table,
                                        [tab1, [{rlog_shard, another_shard}]])
                        ),

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 all() -> mria_ct:all(?MODULE).
 
 init_per_suite(Config) ->
+    mria_ct:start_dist(),
     snabbkaffe:fix_ct_logging(),
     Config.
 

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -736,7 +736,6 @@ t_rlog_schema(_) ->
                ?assert(
                   ?strict_causality( #{ ?snk_kind := "Adding table to a shard"
                                       , shard := _Shard
-                                      , live_change := true
                                       , table := _Table
                                       }
                                    , #{ ?snk_kind := "Shard schema change"

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -98,7 +98,7 @@ t_bootstrap(_) ->
     Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),
     NRecords = 4321,
     ?check_trace(
-                                                %#{timetrap => 30_000},
+       #{timetrap => 30_000},
         try
             Nodes = [Core, Replicant] = mria_ct:start_cluster(mria, Cluster),
             mria_mnesia_test_util:stabilize(1000),
@@ -130,7 +130,8 @@ t_bootstrap(_) ->
         after
             ok = mria_ct:teardown_cluster(Cluster)
         end,
-       []).
+       [ fun mria_rlog_props:no_unexpected_events/1
+       ]).
 
 t_rocksdb_table(_) ->
     EnvOverride = [{mnesia_rocksdb, semantics, fast}],
@@ -171,7 +172,7 @@ t_rocksdb_table(_) ->
         after
             ok = mria_ct:teardown_cluster(Cluster)
         end,
-       []).
+        common_checks()).
 
 t_join_leave_cluster(_) ->
     Cluster = mria_ct:cluster([core, core], []),
@@ -242,7 +243,7 @@ t_remove_from_cluster(_) ->
        after
            ok = mria_ct:teardown_cluster(Cluster)
        end,
-       []).
+       [fun mria_rlog_props:no_unexpected_events/1]).
 
 %% This test runs should walk the replicant state machine through all
 %% the stages of startup and online transaction replication, so it can
@@ -296,18 +297,23 @@ t_rlog_smoke_test(_) ->
            mria_ct:teardown_cluster(Cluster),
            ok
        end,
-       fun([N1, N2, N3], Trace) ->
-               ?assert(mria_rlog_props:no_tlog_gaps(Trace)),
-               %% Ensure that the nodes assumed designated roles:
-               ?projection_complete(node, ?of_kind(rlog_server_start, Trace), [N1, N2]),
-               ?projection_complete(node, ?of_kind(rlog_replica_start, Trace), [N3]),
-               %% TODO: Check that some transactions have been buffered during catchup (to increase coverage):
-               %?assertMatch([_|_], ?of_kind(rlog_replica_store_trans, Trace)),
-               %% Other tests
-               ?assert(mria_rlog_props:replicant_bootstrap_stages(N3, Trace)),
-               ?assert(mria_rlog_props:all_batches_received(Trace)),
-               ?assert(mria_rlog_props:counter_import_check(CounterKey, N3, Trace) > 0)
-       end).
+       [ fun mria_rlog_props:no_tlog_gaps/1
+       , fun mria_rlog_props:no_unexpected_events/1
+       , {"Nodes assume dedicated roles",
+          fun([N1, N2, N3], Trace) ->
+                  ?projection_complete(node, ?of_kind(rlog_server_start, Trace), [N1, N2]),
+                  ?projection_complete(node, ?of_kind(rlog_replica_start, Trace), [N3])
+          end}
+       , {"Bootstrap stages are executed in order",
+          fun([_N1, _N2, N3], Trace) ->
+                  ?assert(mria_rlog_props:replicant_bootstrap_stages(N3, Trace))
+          end}
+       , {"Counter import check",
+          fun([_N1, _N2, N3], Trace) ->
+                  ?assert(mria_rlog_props:counter_import_check(CounterKey, N3, Trace) > 0),
+                  ?assert(mria_rlog_props:all_batches_received(Trace))
+          end}
+       ]).
 
 t_transaction_on_replicant(_) ->
     Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),
@@ -326,7 +332,8 @@ t_transaction_on_replicant(_) ->
        end,
        fun([_N1, N2], Trace) ->
                ?assert(mria_rlog_props:replicant_bootstrap_stages(N2, Trace)),
-               ?assert(mria_rlog_props:all_batches_received(Trace))
+               ?assert(mria_rlog_props:all_batches_received(Trace)),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 %% Check that behavior on error and exception is the same for both backends
@@ -352,7 +359,8 @@ t_abort(_) ->
            mria_ct:teardown_cluster(Cluster)
        end,
        fun(Trace) ->
-               ?assertMatch([], ?of_kind(rlog_import_trans, Trace))
+               ?assertMatch([], ?of_kind(rlog_import_trans, Trace)),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 %% Start processes competing for the key on two core nodes and test
@@ -382,7 +390,8 @@ t_core_node_competing_writes(_) ->
                %% Check that the number of imported transaction equals to the expected number:
                ?assertEqual(NOper * 2, length(Events)),
                %% Check that the ops have been imported in order:
-               snabbkaffe:strictly_increasing(Events)
+               snabbkaffe:strictly_increasing(Events),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 t_rlog_clear_table(_) ->
@@ -401,7 +410,7 @@ t_rlog_clear_table(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       []).
+       common_checks()).
 
 %% Compare behaviour of failing dirty operations on core and replicant:
 t_rlog_dirty_ops_fail(_) ->
@@ -427,7 +436,7 @@ t_rlog_dirty_ops_fail(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       []).
+       common_checks()).
 
 t_middleman(_) ->
     Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),
@@ -449,6 +458,7 @@ t_middleman(_) ->
            mria_ct:teardown_cluster(Cluster)
        end,
        [ fun mria_rlog_props:replicant_no_restarts/1
+       , fun mria_rlog_props:no_unexpected_events/1
        , {"Check that middleman has been invoked",
           fun(Trace) ->
                   length(?of_kind(mria_lib_with_middleman, Trace)) > 0
@@ -474,7 +484,6 @@ t_rlog_dirty_operations(_) ->
            mria_mnesia_test_util:compare_table_contents(test_tab, Nodes),
            ?assertMatch(#{ backend        := rlog
                          , role           := replicant
-                         , shards_in_sync := [test_shard]
                          , shards_down    := []
                          , shard_stats    := #{test_shard :=
                                                    #{ state               := normal
@@ -485,13 +494,13 @@ t_rlog_dirty_operations(_) ->
                                                     , bootstrap_num_keys  := _
                                                     , lag                 := _
                                                     , message_queue_len   := _
-                                                    }}
+                                                    }
+                                              }
                          }, rpc:call(N3, mria_rlog, status, []))
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       [ fun mria_rlog_props:replicant_no_restarts/1
-       ]).
+       common_checks()).
 
 t_rlog_sync_dirty_operations(_) ->
     Cluster = mria_ct:cluster([core, core, replicant], mria_mnesia_test_util:common_env()),
@@ -509,8 +518,7 @@ t_rlog_sync_dirty_operations(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       [ fun mria_rlog_props:replicant_no_restarts/1
-       ]).
+       common_checks()).
 
 t_local_content(_) ->
     Cluster = mria_ct:cluster([core, core, replicant], mria_mnesia_test_util:common_env()),
@@ -582,7 +590,7 @@ t_local_content(_) ->
       after
           mria_ct:teardown_cluster(Cluster)
       end,
-      []).
+      common_checks()).
 
 %% This testcase verifies verifies various modes of mria:ro_transaction
 t_sum_verify(_) ->
@@ -609,12 +617,13 @@ t_sum_verify(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       fun(Trace) ->
-               ?assert(mria_rlog_props:replicant_no_restarts(Trace)),
-               ?assertMatch( [#{result := ok}, #{result := ok}]
-                           , ?of_kind(verify_trans_sum, Trace)
-                           )
-       end).
+       [{"Verify sum property",
+         fun(Trace) ->
+                 ?assertMatch( [#{result := ok}, #{result := ok}]
+                             , ?of_kind(verify_trans_sum, Trace)
+                             )
+         end}
+       |common_checks()]).
 
 %% Test behavior of the replicant waiting for the core node
 t_core_node_down(_) ->
@@ -679,7 +688,6 @@ t_dirty_reads(_) ->
            %% Insert data:
            ok = rpc:call(N1, mria, dirty_write, [{test_tab, Key, Val}]),
            %% Ensure that the replicant still reads the correct value by doing an RPC to the core node:
-           ?block_until(#{?snk_kind := rlog_read_from, source := N1}),
            ?assertEqual([{test_tab, Key, Val}], rpc:call(N2, mnesia, dirty_read, [test_tab, Key])),
            %% Now allow the shard to start:
            ?tp(read1, #{}),
@@ -689,7 +697,7 @@ t_dirty_reads(_) ->
        after
            mria_ct:teardown_cluster(Cluster)
        end,
-       fun(_, Trace) ->
+       fun(Trace) ->
                ?assert(
                   ?strict_causality( #{?snk_kind := read1}
                                    , #{?snk_kind := state_change, to := normal}
@@ -1018,7 +1026,7 @@ compare_persistence_type_shard_contents(ReplicantNodes) ->
       end,
       ReplicantNodes).
 
-assert_create_table_commit_record(Trace, Node, Cores, Name, PersistenceType) ->
+assert_create_table_commit_record(Trace, Node, _Cores, Name, PersistenceType) ->
     ct:pal("checking create table commit record for node ~p, table ~p~n",
            [Node, Name]),
     [ #{ schema_ops := [{op, create_table, Props}]
@@ -1031,7 +1039,7 @@ assert_create_table_commit_record(Trace, Node, Cores, Name, PersistenceType) ->
              lists:keyfind(name, 1, Props) =:= {name, Name}
         ],
     NodeCopies = lists:sort([N || {PT, Ns} <- Props, PT =:= PersistenceType, N <- Ns]),
-    ?assertEqual(Cores, NodeCopies).
+    ?assertEqual(NodeCopies, [Node]).
 
 assert_transaction_commit_record(Trace, Node, Name, rocksdb_copies, Value) ->
     ct:pal("checking transaction commit record for node ~p, table ~p~n",
@@ -1106,3 +1114,8 @@ assert_dirty_commit_record(Trace, Node, Name, PersistenceType, Value) ->
        , tid := {dirty, _}
        },
        Event).
+
+common_checks() ->
+    [ fun mria_rlog_props:replicant_no_restarts/1
+    , fun mria_rlog_props:no_unexpected_events/1
+    ].

--- a/test/mria_autoclean_SUITE.erl
+++ b/test/mria_autoclean_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ all() ->
     [t_autoclean].
 
 init_per_suite(Config) ->
+    mria_ct:start_dist(),
     Config.
 
 end_per_suite(_Config) ->

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@
 -export([ t_autoheal/1
         , t_autoheal_with_replicants/1
         , t_reboot_rejoin/1
+
+        , init_per_suite/1
+        , end_per_suite/1
         ]).
 
 -compile(nowarn_underscore_match).
@@ -204,12 +207,21 @@ assert_partition_contents(Node, #{ running := ExpectedRunning
                                  }) ->
     Running = rpc:call(Node, mria, info, [running_nodes]),
     Stopped = rpc:call(Node, mria, info, [stopped_nodes]),
-    [?assert(lists:member(Expected, Running), #{ node => Node
-                                               , expected => Expected
+    [?assert(lists:member(Expected, Running), #{ from_pov => Node
+                                               , expected_running => Expected
+                                               , running => Running
                                                })
      || Expected <- ExpectedRunning],
-    [?assert(lists:member(Expected, Stopped), #{ node => Node
-                                               , expected => Expected
+    [?assert(lists:member(Expected, Stopped), #{ from_pov => Node
+                                               , expected_stopped => Expected
+                                               , stopped => Stopped
                                                })
      || Expected <- ExpectedStopped],
+    ok.
+
+init_per_suite(Config) ->
+    mria_ct:start_dist(),
+    Config.
+
+end_per_suite(_Config) ->
     ok.

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -195,7 +195,7 @@ assert_replicant_bootstrapped(R, C, Trace) ->
                            , ?snk_meta := #{ node := C }
                            }
                         , #{ ?snk_kind := "Remote RLOG agent died"
-                           , ?snk_meta := #{ node := R }
+                           , ?snk_meta := #{ node := R, shard := test_shard }
                            }
                         , Trace
                         )),

--- a/test/mria_ct.erl
+++ b/test/mria_ct.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 -compile(nowarn_export_all).
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-compile(nowarn_deprecated_function). %% Silence the warnings about slave module
 
 %% @doc Get all the test cases in a CT suite.
 all(Suite) ->

--- a/test/mria_fault_tolerance_suite.erl
+++ b/test/mria_fault_tolerance_suite.erl
@@ -67,7 +67,8 @@ t_agent_restart(_) ->
        fun(N3, Trace) ->
                ?assert(mria_rlog_props:replicant_bootstrap_stages(N3, Trace)),
                mria_rlog_props:counter_import_check(CounterKey, N3, Trace),
-               ?assert(length(?of_kind(snabbkaffe_crash, Trace)) > 1)
+               ?assert(length(?of_kind(snabbkaffe_crash, Trace)) > 1),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 %% Check that an agent dies if its subscriber dies.
@@ -101,6 +102,7 @@ t_rlog_agent_linked_to_subscriber(_) ->
                     , reason     := {shutdown, {subscriber_died, killed}}
                     }],
                   ?of_kind(rlog_agent_terminating, Trace)),
+               mria_rlog_props:no_unexpected_events(Trace),
                ok
        end).
 
@@ -125,7 +127,8 @@ t_rand_error_injection(_) ->
        end,
        fun(N3, Trace) ->
                ?assert(mria_rlog_props:replicant_bootstrap_stages(N3, Trace)),
-               ?assert(mria_rlog_props:counter_import_check(CounterKey, N3, Trace) > 0)
+               ?assert(mria_rlog_props:counter_import_check(CounterKey, N3, Trace) > 0),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 %% This testcase verifies verifies various modes of mria:ro_transaction
@@ -183,7 +186,8 @@ t_rlog_replica_reconnect(_) ->
        end,
        fun(Trace) ->
                Seqnos = ?projection(seqno, ?of_kind("Connected to the core node", Trace)),
-               snabbkaffe:increasing(Seqnos)
+               snabbkaffe:increasing(Seqnos),
+               mria_rlog_props:no_unexpected_events(Trace)
        end).
 
 %% Remove the injected errors and check table consistency

--- a/test/mria_fault_tolerance_suite.erl
+++ b/test/mria_fault_tolerance_suite.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 all() -> mria_ct:all(?MODULE).
 
 init_per_suite(Config) ->
+    mria_ct:start_dist(),
     Config.
 
 end_per_suite(_Config) ->

--- a/test/mria_fault_tolerance_suite.erl
+++ b/test/mria_fault_tolerance_suite.erl
@@ -185,7 +185,7 @@ t_rlog_replica_reconnect(_) ->
            mria_ct:teardown_cluster(Cluster)
        end,
        fun(Trace) ->
-               Seqnos = ?projection(seqno, ?of_kind("Connected to the core node", Trace)),
+               Seqnos = [SN || #{?snk_kind := "Connected to the core node", shard := test_shard, seqno := SN} <- Trace],
                snabbkaffe:increasing(Seqnos),
                mria_rlog_props:no_unexpected_events(Trace)
        end).

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ all() ->
     mria_ct:all(?MODULE).
 
 init_per_suite(Config) ->
+    mria_ct:start_dist(),
     snabbkaffe:fix_ct_logging(),
     Config.
 

--- a/test/mria_membership_SUITE.erl
+++ b/test/mria_membership_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -24,6 +24,13 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() -> mria_ct:all(?MODULE).
+
+init_per_suite(Config) ->
+    mria_ct:start_dist(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
 
 init_per_testcase(_TestCase, Config) ->
     ok = meck:new(mria_mnesia, [non_strict, passthrough, no_history]),

--- a/test/mria_mnesia_SUITE.erl
+++ b/test/mria_mnesia_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-compile(nowarn_deprecated_function). %% Silence the warnings about slave module
 
 all() ->
     mria_ct:all(?MODULE).

--- a/test/mria_mnesia_SUITE.erl
+++ b/test/mria_mnesia_SUITE.erl
@@ -49,10 +49,10 @@ end_per_testcase(TestCase, Config) ->
 t_cluster_core_nodes_on_replicant(_) ->
     Cluster = mria_ct:cluster([core, core, replicant], mria_mnesia_test_util:common_env()),
     ?check_trace(
-       #{timetrap => 10000},
+       #{timetrap => 30000},
        try
            [N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
-           mria_mnesia_test_util:wait_full_replication(Cluster, 5000),
+           mria_mnesia_test_util:wait_full_replication(Cluster, 15000),
            ?assertEqual(
               [N1, N2],
               erpc:call(N3, mria_mnesia, cluster_nodes, [cores])),
@@ -63,7 +63,7 @@ t_cluster_core_nodes_on_replicant(_) ->
               [N1, N2, N3],
               erpc:call(N3, mria_mnesia, cluster_nodes, [running])),
            slave:stop(N2),
-           mria_mnesia_test_util:wait_full_replication(Cluster, 5000),
+           timer:sleep(5000),
            ?assertEqual(
               [N1, N2, N3],
               erpc:call(N3, mria_mnesia, cluster_nodes, [all])),
@@ -107,52 +107,60 @@ t_join_after_node_down(_) ->
 t_diagnosis_tab(_)->
     TestTab = test_tab_1,
     Cluster = mria_ct:cluster([core, core], []),
-    [N1, N2] = mria_ct:start_cluster(mria, Cluster),
-    try
-        %% Create a test table
-        ok = rpc:call(N1, mria, create_table,
-                      [TestTab, [{rlog_shard, my_shard},
-                                 {storage, disc_copies}
-                                ]
-                      ]),
-        %% Ensure table is ready
-        ?assertEqual(ok, rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 1000])),
-        ?assertEqual(ok, rpc:call(N2, mnesia, wait_for_tables, [[TestTab], 1000])),
-        %% Kill N1
-        ok = slave:stop(N1),
-        %% Kill N2, N2 knows N1 is down
-        ok = slave:stop(N2),
-        ?assertEqual({badrpc, nodedown}, rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 1000])),
-        ?assertEqual({badrpc, nodedown}, rpc:call(N2, mnesia, wait_for_tables, [[TestTab], 1000])),
+    ?check_trace(
+       #{timetrap => 30_000},
+       try
+           [N1, N2] = mria_ct:start_cluster(mria, Cluster),
+           %% Create a test table
+           ok = rpc:call(N2, mria, create_table,
+                         [TestTab, [{rlog_shard, my_shard},
+                                    {storage, disc_copies}
+                                   ]
+                         ]),
+           %% Ensure table is ready
+           ?assertEqual(ok, rpc:call(N1, mria, wait_for_tables, [[TestTab]])),
+           ?assertEqual(ok, rpc:call(N2, mria, wait_for_tables, [[TestTab]])),
+           ?assertEqual([N1, N2], lists:sort(rpc:call(N1, mria_mnesia, running_nodes, []))),
+           %% Kill N1
+           ?tp(notice, ?FUNCTION_NAME, #{step => stop_n1}),
+           ok = slave:stop(N1),
+           %% Kill N2, N2 knows N1 is down
+           ?tp(notice, ?FUNCTION_NAME, #{step => stop_n2}),
+           ok = slave:stop(N2),
+           ?assertEqual({badrpc, nodedown}, rpc:call(N1, mria, wait_for_tables, [[TestTab]])),
+           ?assertEqual({badrpc, nodedown}, rpc:call(N2, mria, wait_for_tables, [[TestTab]])),
 
-        %% Start N1, N1 mnesia doesn't know N2 is down
-        N1 = mria_ct:start_slave(node, n1),
-        ok = rpc:call(N1, mria, start, []),
+           %% Start N1, N1 mnesia doesn't know N2 is down
+           ?tp(notice, ?FUNCTION_NAME, #{step => start_n1}),
+           N1 = mria_ct:start_slave(node, n1),
+           ok = rpc:call(N1, mria, start, []),
+           ?assertEqual([N2], lists:sort(rpc:call(N1, mria_mnesia, cluster_nodes, [stopped]))),
+           %% N1 is waiting for N2 since N1 knows N2 has the latest copy of data
+           ?assertEqual( {timeout,[test_tab_1]}
+                       , rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 1000])),
+           ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
 
-        %% N1 is waiting for N2 since N1 knows N2 has the latest copy of data
-        ?assertEqual( {timeout,[test_tab_1]}
-                    , rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 5000])),
-        ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
+           %% Start N2 only, but not mnesia
+           ?tp(notice, ?FUNCTION_NAME, #{step => start_n2_node}),
+           N2 = mria_ct:start_slave(node, n2),
+           %% Check N1 still waits for the mnesia on N2
+           ?assertEqual( {timeout,[test_tab_1]}
+                       , rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 1000])),
+           ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
 
-        %% Start N2 only, but not mnesia
-        N2 = mria_ct:start_slave(node, n2),
-        %% Check N1 still waits for the mnesia on N2
-        ?assertEqual( {timeout,[test_tab_1]}
-                    , rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 5000])),
-        ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
+           %% Start mria on N2.
+           ?tp(notice, ?FUNCTION_NAME, #{step => start_n2}),
+           ?wait_async_action( ok = rpc:call(N2, mria, start, [])
+                             , #{?snk_kind := "Mria is running", ?snk_meta := #{node := N2}}
+                             ),
 
-        %% Start mria on N2.
-        ok = rpc:call(N2, mria, start, []),
-
-        %% Check tables are loaded on two
-        ?assertEqual(ok, rpc:call(N1, mnesia, wait_for_tables, [[TestTab], 1000])),
-        ?assertEqual(ok, rpc:call(N2, mnesia, wait_for_tables, [[TestTab], 1000])),
-        ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
-        ?assertEqual(ok, rpc:call(N2, mria_mnesia, diagnosis, [[TestTab]]))
-
-    after
-        ?assertEqual({atomic, ok}, rpc:call(N2, mnesia, delete_table, [TestTab])),
-        ok = mria_ct:stop_slave(N1),
-        ok = mria_ct:stop_slave(N2)
-    end,
-    ok.
+           %% Check tables are loaded on two
+           ?assertEqual(ok, rpc:call(N1, mria, wait_for_tables, [[TestTab]])),
+           ?assertEqual(ok, rpc:call(N2, mria, wait_for_tables, [[TestTab]])),
+           ?assertEqual(ok, rpc:call(N1, mria_mnesia, diagnosis, [[TestTab]])),
+           ?assertEqual(ok, rpc:call(N2, mria_mnesia, diagnosis, [[TestTab]])),
+           ?assertEqual({atomic, ok}, rpc:call(N2, mnesia, delete_table, [TestTab]))
+       after
+           mria_ct:teardown_cluster(Cluster)
+       end,
+       []).

--- a/test/mria_mnesia_SUITE.erl
+++ b/test/mria_mnesia_SUITE.erl
@@ -28,6 +28,7 @@ all() ->
     mria_ct:all(?MODULE).
 
 init_per_suite(Config) ->
+    mria_ct:start_dist(),
     snabbkaffe:fix_ct_logging(),
     Config.
 

--- a/test/mria_node_monitor_SUITE.erl
+++ b/test/mria_node_monitor_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ all() ->
 
 init_per_suite(Config) ->
     mria:start(),
+    mria_ct:start_dist(),
     Config.
 
 end_per_suite(_Config) ->

--- a/test/mria_node_monitor_SUITE.erl
+++ b/test/mria_node_monitor_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/mria_proper_mixed_cluster_suite.erl
+++ b/test/mria_proper_mixed_cluster_suite.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -62,3 +62,10 @@ precondition(_State, {call, _Mod, execute, [_Node, Op]}) ->
 precondition(State, Op) -> mria_proper_utils:precondition(State, Op).
 postcondition(State, Op, Res) -> mria_proper_utils:postcondition(State, Op, Res).
 next_state(State, Res, Op) -> mria_proper_utils:next_state(State, Res, Op).
+
+init_per_suite(Config) ->
+    mria_ct:start_dist(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.

--- a/test/mria_proper_suite.erl
+++ b/test/mria_proper_suite.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -47,3 +47,11 @@ command(State) -> mria_proper_utils:command(State).
 precondition(State, Op) -> mria_proper_utils:precondition(State, Op).
 postcondition(State, Op, Res) -> mria_proper_utils:postcondition(State, Op, Res).
 next_state(State, Res, Op) -> mria_proper_utils:next_state(State, Res, Op).
+
+init_per_suite(Config) ->
+    mria_ct:start_dist(),
+    snabbkaffe:fix_ct_logging(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.

--- a/test/mria_proper_utils.erl
+++ b/test/mria_proper_utils.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ prop(ClusterConfig, PropModule) ->
            [check_state(Cmds, State, Node) || Node <- Nodes],
            {History, State, Result}
        after
-           mria_ct:teardown_cluster(Cluster)
+           catch mria_ct:teardown_cluster(Cluster)
        end,
        fun({_History, _State, Result}, _Trace) ->
                ?assertMatch(ok, Result),

--- a/test/mria_rlog_props.erl
+++ b/test/mria_rlog_props.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@
 %%================================================================================
 
 %% Check that each replicant didn't restart
-replicant_no_restarts(Trace) ->
+replicant_no_restarts(Trace0) ->
+    %% Ignore everything that happens after cluster teardown:
+    {Trace, _} = ?split_trace_at(#{?snk_kind := teardown_cluster}, Trace0),
     StartEvents = ?projection([node, shard], ?of_kind(rlog_replica_start, Trace)),
     ?assertEqual(length(StartEvents), length(lists:usort(StartEvents))),
     true.

--- a/test/mria_rlog_props.erl
+++ b/test/mria_rlog_props.erl
@@ -18,7 +18,8 @@
 
 -compile(nowarn_underscore_match).
 
--export([ replicant_no_restarts/1
+-export([ no_unexpected_events/1
+        , replicant_no_restarts/1
         , replicant_bootstrap_stages/2
         , all_intercepted_commit_logs_received/1
         , all_batches_received/1
@@ -30,10 +31,18 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("mria_rlog.hrl").
 
 %%================================================================================
 %% Checks
 %%================================================================================
+
+%% Check that there were no unexpected events
+no_unexpected_events(Trace0) ->
+    %% Ignore everything that happens after cluster teardown:
+    {Trace, _} = ?split_trace_at(#{?snk_kind := teardown_cluster}, Trace0),
+    ?assertMatch([], ?of_kind(?unexpected_event_kind, Trace)),
+    true.
 
 %% Check that each replicant didn't restart
 replicant_no_restarts(Trace0) ->
@@ -172,6 +181,14 @@ check_transaction_replay_sequence(Max, Prev, [Next|_]) ->
 %%================================================================================
 %% Unit tests
 %%================================================================================
+
+%% Find all node/shard pairs for the replicants:
+%% -spec find_replicant_shards(snabbkaffe:trace()) -> {node(), mria_rlog:shard()}.
+%% find_replicant_shards(Trace) ->
+%%     lists:usort([{Node, Shard} || #{ ?snk_kind := "starting_rlog_shard"
+%%                                    , shard := Shard
+%%                                    , ?snk_meta := #{node := Node, domain := [mria, rlog, replica]}
+%%                                    } <- Trace]).
 
 check_transaction_replay_sequence_test() ->
     ?assert(check_transaction_replay_sequence([])),

--- a/test/mria_rlog_props.erl
+++ b/test/mria_rlog_props.erl
@@ -91,6 +91,7 @@ all_intercepted_commit_logs_received(Trace0) ->
                                     ]),
                  case Event of
                      #{schema_ops := [_ | _]} -> false;
+                     #{?snk_meta := #{shard := ?mria_meta_shard}} -> false;
                      #{ram_copies := [{{mria_schema, _}, _, _} | _]} -> false;
                      _ -> true
                  end],

--- a/test/mria_transaction_gen.erl
+++ b/test/mria_transaction_gen.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/mria_transaction_gen.erl
+++ b/test/mria_transaction_gen.erl
@@ -15,6 +15,7 @@
 %%--------------------------------------------------------------------
 -module(mria_transaction_gen).
 
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -export([ init/0
@@ -213,7 +214,8 @@ do_trans_verify(Delay) ->
                       Sum = sum_keys(),
                       timer:sleep(Delay),
                       [#test_tab{val = Expected}] = mnesia:read(test_tab, sum),
-                      Sum == Expected
+                      ?assertEqual(Sum, Expected),
+                      true
               end
       end).
 


### PR DESCRIPTION
- Fix status of running and stopped nodes on the replicants
- Update dependencies to the latest versions
- Fix flaky `mria_rlog_props:replicant_no_restarts` property
- Fix a potential bug when replica gets stuck in disconnected state after it receives an unexpected message
- Fix a potential race condition between replica and importer worker processes
- Perform schema replication using a dedicated shard
- Run CI on OTP25
  