### PR TITLE
Handle the situation when one of the core nodes leaves the cluster

### DIFF
--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -26,6 +26,8 @@
         , strict_mode/0
         , replay_batch_size/0
         , set_replay_batch_size/1
+        , lb_timeout/0
+        , lb_poll_interval/0
 
         , load_config/0
         , erase_all_config/0
@@ -131,6 +133,14 @@ replay_batch_size() ->
 -spec set_replay_batch_size(non_neg_integer()) -> ok.
 set_replay_batch_size(N) ->
     persistent_term:put(?mria(replay_batch_size), N).
+
+-spec lb_timeout() -> timeout().
+lb_timeout() ->
+    application:get_env(mria, rlog_lb_update_timeout, 300).
+
+-spec lb_poll_interval() -> non_neg_integer().
+lb_poll_interval() ->
+    application:get_env(mria, rlog_lb_update_interval, 1000).
 
 -spec load_config() -> ok.
 load_config() ->

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -267,23 +267,7 @@ core_clusters(NewCoreNodes) ->
                          end
                  end,
                  NewCoreNodes),
-    %% Unless mnesia schema is totally broken, `mria_mnesia:db_nodes'
-    %% returns the same value on all nodes that belong to the same
-    %% cluster.  Hence we can assume that the first
-    %% (lexicographically) db_node can be used as the identity of the
-    %% cluster:
-    NodeClusters = [{N, lists:min(DBNodes)} || {N, DBNodes} <- NodeInfo],
-    %% Group the nodes into clusters according to the first db_node:
-    Clusters = lists:foldl(
-                 fun({Node, ClusterId}, Clusters) ->
-                         maps:update_with(ClusterId,
-                                          fun(Nodes) -> [Node|Nodes] end,
-                                          [Node],
-                                          Clusters)
-                 end,
-                 #{},
-                 NodeClusters),
-    [lists:usort(Val) || Val <- maps:values(Clusters)].
+    lists:usort([lists:usort(DBNodes0) || {N, DBNodes0} <- NodeInfo]).
 
 -spec ping_core_nodes([node()]) -> ok.
 ping_core_nodes(NewCoreNodes) ->

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -228,7 +228,7 @@ maybe_report_netsplit(OldNodes, Clusters) ->
             case get(Alarm) of
                 undefined ->
                     put(Alarm, true),
-                    ?tp(error, mria_lb_spit_brain,
+                    ?tp(error, mria_lb_split_brain,
                         #{ previous_cores => OldNodes
                          , clusters => Clusters
                          , node => node()

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -192,13 +192,13 @@ list_core_nodes(OldCoreNodes) ->
                     end,
     CoreClusters = core_clusters(lists:usort(NewCoreNodes0)),
     {IsChanged, NewCoreNodes} = find_best_cluster(OldCoreNodes, CoreClusters),
-    ?tp(mria_lb_core_discovery_new_nodes,
-        #{ previous_cores => OldCoreNodes
-         , returned_cores => NewCoreNodes
-         , ignored_nodes => NewCoreNodes0 -- NewCoreNodes
-         , is_changed => IsChanged
-         , node => node()
-         }),
+    IsChanged andalso
+        ?tp(info, mria_lb_core_discovery_new_nodes,
+            #{ previous_cores => OldCoreNodes
+             , returned_cores => NewCoreNodes
+             , ignored_nodes => NewCoreNodes0 -- NewCoreNodes
+             , node => node()
+             }),
     {IsChanged, NewCoreNodes}.
 
 -spec find_best_cluster([node()], [[node()]]) -> {_Changed :: boolean(), [node()]}.
@@ -273,10 +273,6 @@ core_clusters(NewCoreNodes) ->
     %% (lexicographically) db_node can be used as the identity of the
     %% cluster:
     NodeClusters = [{N, lists:min(DBNodes)} || {N, DBNodes} <- NodeInfo],
-    ?tp(debug, mria_lb_core_discovery_raw_return,
-        #{ node_clusters => NodeClusters
-         , node_info => NodeInfo
-         }),
     %% Group the nodes into clusters according to the first db_node:
     Clusters = lists:foldl(
                  fun({Node, ClusterId}, Clusters) ->

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -163,8 +163,7 @@ shard_of_table(Table) ->
 -spec shards() -> [mria_rlog:shard()].
 shards() ->
     MS = {#?schema{mnesia_table = '_', shard = '$1', config = '_', storage = '_'}, [], ['$1']},
-    {atomic, Shards} = mnesia:transaction(fun mnesia:select/2, [?schema, [MS]], infinity),
-    lists:usort(Shards).
+    lists:usort(ets:select(?schema, [MS])).
 
 -spec wait_for_tables([mria:table()]) -> ok | {error, _Reason}.
 wait_for_tables(Tables) ->

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1153,4 +1153,5 @@ assert_dirty_commit_record(Trace, Node, Name, PersistenceType, Value) ->
 common_checks() ->
     [ fun mria_rlog_props:replicant_no_restarts/1
     , fun mria_rlog_props:no_unexpected_events/1
+    , fun mria_rlog_props:no_split_brain/1
     ].

--- a/test/mria_ct.erl
+++ b/test/mria_ct.erl
@@ -178,7 +178,7 @@ wait_running(Node, Timeout) ->
 
 stop_slave(Node) ->
     ok = cover:stop([Node]),
-    rpc:call(Node, mnesia, stop, []),
+    rpc:call(Node, mria, stop, []),
     mnesia:delete_schema([Node]),
     slave:stop(Node).
 

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -177,6 +177,7 @@ t_core_node_discovery(_Config) ->
            %% final list.  So the LB now decided to fall back to C1
            %% partition:
            clear_core_node_list(R1),
+           ?tp(test_inject_replicant_role, #{}),
            with_role(
              C2, replicant,
              fun() ->
@@ -279,10 +280,10 @@ with_reported_cores(Node, CoresToReport, TestFun) ->
 
 with_role(Node, Role, TestFun) ->
     ok = erpc:call(Node, meck, new, [mria_rlog, [passthrough, no_history, no_link]]),
-    ok = erpc:call(Node, meck, expect, [mria_rlog, role,
+    ok = erpc:call(Node, meck, expect, [mria_config, whoami,
                                         fun() -> Role end]),
     try
         TestFun()
     after
-        ok = erpc:call(Node, meck, unload, [mria_rlog])
+        ok = erpc:call(Node, meck, unload, [mria_config])
     end.

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -165,7 +165,7 @@ t_core_node_discovery(_Config) ->
                      {_, {ok, _}} =
                          ?wait_async_action(
                             {R1, mria_lb} ! update,
-                            #{ ?snk_kind := mria_lb_spit_brain
+                            #{ ?snk_kind := mria_lb_split_brain
                              , node := R1
                              , clusters := [_, _]
                              }, 5000),
@@ -222,7 +222,7 @@ t_core_node_leave(_Config) ->
            ?assertMatch([C1, C3], lists:sort(rpc:call(C1, mria_mnesia, db_nodes, []))),
            %% Ensure the replicant detected the split:
            {R1, mria_lb} ! update,
-           ?block_until(#{ ?snk_kind := mria_lb_spit_brain
+           ?block_until(#{ ?snk_kind := mria_lb_split_brain
                          , clusters := [_, _]
                          }),
            %% It should prefer the larger cluster:

--- a/test/mria_rlog_props.erl
+++ b/test/mria_rlog_props.erl
@@ -20,6 +20,7 @@
 
 -export([ no_unexpected_events/1
         , replicant_no_restarts/1
+        , no_split_brain/1
         , replicant_bootstrap_stages/2
         , all_intercepted_commit_logs_received/1
         , all_batches_received/1
@@ -50,6 +51,11 @@ replicant_no_restarts(Trace0) ->
     {Trace, _} = ?split_trace_at(#{?snk_kind := teardown_cluster}, Trace0),
     StartEvents = ?projection([node, shard], ?of_kind(rlog_replica_start, Trace)),
     ?assertEqual(length(StartEvents), length(lists:usort(StartEvents))),
+    true.
+
+no_split_brain(Trace0) ->
+    {Trace, _} = ?split_trace_at(#{?snk_kind := teardown_cluster}, Trace0),
+    ?assertMatch([], ?of_kind(mria_lb_spit_brain, Trace)),
     true.
 
 %% Check that replicant FSM goes through all the stages in the right sequence


### PR DESCRIPTION
Prior to this fix, the LB got pretty much stuck any time it detected a split in the core cluster. 
Now it does the following:
- Collects mnesia cluster view from all discovered core nodes 
- If the core cluster is partitioned, it tries to stick to a single partition, which is selected according to the following heuristics:
  + It contains most of the old core nodes
  + In case of a tie, it picks the biggest partition