### PR TITLE
EMQX-9021

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps,
- [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.5"}}},
+ [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.7"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.11"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.11"}}},
-  {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.3"}}}
+  {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.4"}}}
  ]}.
 
 {erl_opts,

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.11"}}},
-  {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.2"}}}
+  {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.3"}}}
  ]}.
 
 {erl_opts,

--- a/src/mria_app.erl
+++ b/src/mria_app.erl
@@ -35,10 +35,7 @@ start(_Type, _Args) ->
     mria_mnesia:ensure_schema(),
     mria_mnesia:ensure_started(),
     ?tp(notice, "Starting shards", #{}),
-    Sup = mria_sup:start_link(),
-    ?tp(notice, "Mria is running", #{}),
-    mria_lib:exec_callback_async(start),
-    Sup.
+    mria_sup:start_link().
 
 stop(_State) ->
     mria_config:erase_all_config(),

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -181,7 +181,7 @@ shard_transport(Shard) ->
 
 -spec load_shard_config(mria_rlog:shard(), [mria:table()]) -> ok.
 load_shard_config(Shard, Tables) ->
-    ?tp(notice, "Setting RLOG shard config",
+    ?tp(info, "Setting RLOG shard config",
         #{ shard => Shard
          , tables => Tables
          }),

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -200,7 +200,7 @@ cluster_view() ->
                    || Status <- [running, stopped]]).
 
 %% @doc Cluster nodes.
--spec(cluster_nodes(all | running | stopped | cores) -> [node()]).
+-spec(cluster_nodes(all | running | stopped) -> [node()]).
 cluster_nodes(all) ->
     db_nodes();
 cluster_nodes(running) ->

--- a/src/mria_rlog_replica.erl
+++ b/src/mria_rlog_replica.erl
@@ -242,7 +242,7 @@ initiate_local_replay(D) ->
 
 -spec handle_bootstrap_complete(mria_rlog_server:checkpoint(), data()) -> fsm_result().
 handle_bootstrap_complete(Checkpoint, D) ->
-    ?tp(notice, "Bootstrap of the shard is complete",
+    ?tp(info, "Bootstrap of the shard is complete",
         #{ checkpoint => Checkpoint
          , shard      => D#d.shard
          }),
@@ -384,12 +384,12 @@ try_connect(Shard, Checkpoint) ->
 try_connect([], _, _) ->
     {error, no_core_available};
 try_connect([Node|Rest], Shard, Checkpoint) ->
-    ?tp(info, "Trying to connect to the core node",
+    ?tp(debug, "Trying to connect to the core node",
         #{ node => Node
          }),
     case mria_rlog:subscribe(Shard, Node, self(), Checkpoint) of
         {ok, NeedBootstrap, Agent, TableSpecs, SeqNo} ->
-            ?tp(notice, "Connected to the core node",
+            ?tp(debug, "Connected to the core node",
                 #{ shard => Shard
                  , node  => Node
                  , seqno => SeqNo
@@ -397,7 +397,7 @@ try_connect([Node|Rest], Shard, Checkpoint) ->
             link(Agent),
             {ok, NeedBootstrap, Node, Agent, TableSpecs, SeqNo};
         Err ->
-            ?tp(info, "Failed to connect to the core node",
+            ?tp(debug, "Failed to connect to the core node",
                 #{ node => Node
                  , reason => Err
                  }),

--- a/src/mria_rlog_server.erl
+++ b/src/mria_rlog_server.erl
@@ -126,7 +126,7 @@ handle_continue(post_init, {Parent, Shard}) ->
     AgentSup = mria_core_shard_sup:start_agent_sup(Parent, Shard),
     BootstrapperSup = mria_core_shard_sup:start_bootstrapper_sup(Parent, Shard),
     mria_status:notify_shard_up(Shard, self()),
-    ?tp(notice, "Shard fully up",
+    ?tp(info, "Shard fully up",
         #{ node  => node()
          , shard => Shard
          }),

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -152,7 +152,10 @@ shard_of_table(Table) ->
 %% @private Return the list of known shards
 -spec shards() -> [mria_rlog:shard()].
 shards() ->
-    MS = {#?schema{mnesia_table = '_', shard = '$1', config = '_', storage = '_'}, [], ['$1']},
+    MS = { #?schema{mnesia_table = '_', shard = '$1', config = '_', storage = '_'}
+         , [{'=/=', '$1', ?LOCAL_CONTENT_SHARD}]
+         , ['$1']
+         },
     lists:usort(ets:select(?schema, [MS])).
 
 -spec wait_for_tables([mria:table()]) -> ok | {error, _Reason}.

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -186,7 +186,7 @@ init([]) ->
     State0 = boostrap(),
     {ok, _} = mnesia:subscribe({table, ?schema, simple}),
     %% Recreate all the known tables:
-    ?tp(notice, "Converging schema", #{}),
+    ?tp(info, "Converging schema", #{}),
     Specs = table_specs_of_shard('_'),
     State = converge_schema(Specs, State0),
     {ok, State}.

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -41,7 +41,9 @@
          local_table_present/1,
          notify_local_table/1,
 
-         notify_agent_connect/3, notify_agent_disconnect/2, notify_agent_disconnect/1
+         notify_agent_connect/3, notify_agent_disconnect/2, notify_agent_disconnect/1,
+
+         waiting_shards/0
         ]).
 
 %% gen_server callbacks:
@@ -300,6 +302,11 @@ notify_local_table(Table) ->
 -spec local_table_present(mria:table()) -> true.
 local_table_present(Table) ->
     optvar:read(?optvar({?local_table, Table})).
+
+-spec waiting_shards() -> [mria_rlog:shard()].
+waiting_shards() ->
+    [Shard || ?optvar({?upstream_pid, Shard}) <- optvar:list_all(),
+              not optvar:is_set({?upstream_pid, Shard})].
 
 %%================================================================================
 %% gen_server callbacks:

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -80,7 +80,10 @@
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-%% @doc Return core node used as the upstream for the replica
+%% @doc Return name of the core node that is _currently serving_ the
+%% downstream shard. Note the difference in behavior as compared with
+%% `get_core_node'. Returns `disconnected' if the local replica of the
+%% shard is down.
 -spec upstream_node(mria_rlog:shard()) -> {ok, node()} | disconnected.
 upstream_node(Shard) ->
     case upstream(Shard) of
@@ -95,6 +98,12 @@ upstream(Shard) ->
         {ok, Pid} -> {ok, Pid};
         undefined -> disconnected
     end.
+
+%% @doc Return a core node that _might_ be able to serve the specified
+%% shard.
+-spec get_core_node(mria_rlog:shard(), timeout()) -> {ok, node()} | timeout.
+get_core_node(Shard, Timeout) ->
+    optvar:read(?optvar({?core_node, Shard}), Timeout).
 
 -spec notify_shard_up(mria_rlog:shard(), _AgentPid :: pid()) -> ok.
 notify_shard_up(Shard, Upstream) ->
@@ -178,12 +187,6 @@ get_shard_lag(Shard) ->
                     RemoteSeqNo - MySeqNo
             end
     end.
-
-%% Get a healthy core node that has the specified shard, and can
-%% accept or RPC calls.
--spec get_core_node(mria_rlog:shard(), timeout()) -> {ok, node()} | timeout.
-get_core_node(Shard, Timeout) ->
-    optvar:read(?optvar({?core_node, Shard}), Timeout).
 
 -spec wait_for_shards([mria_rlog:shard()], timeout()) -> ok | {timeout, [mria_rlog:shard()]}.
 wait_for_shards(Shards, Timeout) ->

--- a/src/mria_sup.erl
+++ b/src/mria_sup.erl
@@ -39,7 +39,7 @@ post_init(Parent) ->
     proc_lib:init_ack(Parent, {ok, self()}),
     %% Exec the start callback, but first make sure the schema is in
     %% sync:
-    ok = mria_status:wait_for_shards([?mria_meta_shard], infinity),
+    ok = mria_rlog:wait_for_shards([?mria_meta_shard], infinity),
     ?tp(notice, "Mria is running", #{}),
     mria_lib:exec_callback(start).
 

--- a/src/mria_sup.erl
+++ b/src/mria_sup.erl
@@ -36,11 +36,11 @@ is_running() ->
     is_pid(whereis(?MODULE)).
 
 post_init(Parent) ->
-    ?tp(notice, "Mria is running", #{}),
     proc_lib:init_ack(Parent, {ok, self()}),
     %% Exec the start callback, but first make sure the schema is in
     %% sync:
     ok = mria_status:wait_for_shards([?mria_meta_shard], infinity),
+    ?tp(notice, "Mria is running", #{}),
     mria_lib:exec_callback(start).
 
 -spec init(mria:backend()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
@@ -91,7 +91,7 @@ post_init_child() ->
     #{ id => post_init
      , start => {proc_lib, start_link, [?MODULE, post_init, [self()]]}
      , restart => temporary
-     , shutdown => brutal_kill
+     , shutdown => 5_000
      , type => worker
      , modules => []
      }.

--- a/src/mria_sup.erl
+++ b/src/mria_sup.erl
@@ -20,7 +20,10 @@
 
 -export([start_link/0, stop/0, is_running/0]).
 
--export([init/1]).
+-export([init/1, post_init/1]).
+
+-include("mria_rlog.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
 
 start_link() ->
     Backend = mria_rlog:backend(),
@@ -32,6 +35,14 @@ stop() ->
 is_running() ->
     is_pid(whereis(?MODULE)).
 
+post_init(Parent) ->
+    ?tp(notice, "Mria is running", #{}),
+    proc_lib:init_ack(Parent, {ok, self()}),
+    %% Exec the start callback, but first make sure the schema is in
+    %% sync:
+    ok = mria_status:wait_for_shards([?mria_meta_shard], infinity),
+    mria_lib:exec_callback(start).
+
 -spec init(mria:backend()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init(mnesia) ->
     {ok, {#{ strategy => one_for_all
@@ -41,7 +52,8 @@ init(mnesia) ->
           [child(mria_status, worker),
            child(mria_schema, worker),
            child(mria_membership, worker),
-           child(mria_node_monitor, worker)
+           child(mria_node_monitor, worker),
+           post_init_child()
           ]}};
 init(rlog) ->
     {ok, {#{ strategy => one_for_all
@@ -52,7 +64,8 @@ init(rlog) ->
            child(mria_schema, worker),
            child(mria_membership, worker),
            child(mria_node_monitor, worker),
-           child(mria_rlog_sup, supervisor)
+           child(mria_rlog_sup, supervisor),
+           post_init_child()
           ]}}.
 
 child(Mod, worker) ->
@@ -71,3 +84,14 @@ child(Mod, supervisor) ->
        type     => supervisor,
        modules  => [Mod]
       }.
+
+%% Simple worker process that runs the start callback. We put it into
+%% the supervision tree to make sure it doesn't outlive mria app
+post_init_child() ->
+    #{ id => post_init
+     , start => {proc_lib, start_link, [?MODULE, post_init, [self()]]}
+     , restart => temporary
+     , shutdown => brutal_kill
+     , type => worker
+     , modules => []
+     }.

--- a/test/mria_helper_tab.erl
+++ b/test/mria_helper_tab.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix problem when running `mria:join(Node), mria:leave(), mria:join(Node)` sequence of actions on the replicant node.

Oftentimes it leads to hangup of the `start` callback. I've identified two reasons for this behavior:

- Mria application restarts for both `join` and `leave`. I didn't take into account that OTP's `application_master` module kills _all_ processes with the group leader matching the pid of the master process of the stopped app. It includes `optvar` "waker" processes, when they are started from inside `mria` supervision tree. Prior to ver. `1.0.4` optvar library couldn't handle crashes of the waker processes, and never unblocked the readers.
- Start callback may involve calls to the application controller. When the replicant leaves the cluster, all tables are blocked until it connects to another core node. It means applications that wait for table can block application controller, and the next invocation of the start callback cannot succeed.