### PR TITLE
Mria mnesia cleanup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,16 +24,18 @@
 
 %% Check layer violations (TODO: make it stricter and remove all exemptions):
 {xref_queries,
- [ {"closure(E) | mria_mnesia : Mod || [mria, mria_lb, mria_schema] : Mod", []}
- , {"closure(E) | mria_membership : Mod || [mria, mria_lb, mria_schema] : Mod", []}
- , {"closure(E) | mria_status : Mod || [mria, mria_lb, mria_schema, mria_membership, mria_node_monitor, mria_rlog] : Mod",
-    [{{mria_status,get_shard_lag,1}, {mria_rlog,role,0}},
-     {{mria_status,get_shard_stats,1}, {mria_lb,core_node_weight,1}},
-     {{mria_status,get_shard_stats,1}, {mria_rlog,role,0}},
+ [ {"closure(E) | mria_status : Mod || [mria, mria_lb, mria_schema, mria_membership, mria_node_monitor, mria_rlog] : Mod",
+    [{{mria_status,get_shard_stats,1}, {mria_lb,core_node_weight,1}},
      {{mria_status,shards_down,0}, {mria_schema,shards,0}},
      {{mria_status,shards_status,0}, {mria_schema,shards,0}},
      {{mria_status,shards_syncing,0}, {mria_schema,shards,0}},
      {{mria_status,shards_up,0}, {mria_schema,shards,0}}]}
+ , {"closure(E) | mria_schema : Mod || [mria, mria_lb, mria_node_monitor, mria_membership, mria_rlog] : Mod",
+    []}
+ , {"closure(E) | mria_mnesia : Mod || [mria, mria_lb, mria_schema, mria_node_monitor, mria_membership, mria_rlog] : Mod",
+    [{{mria_mnesia,join_cluster,1}, {mria_rlog,role,1}}]}
+ , {"closure(E) | mria_membership : Mod || [mria, mria_lb, mria_schema, mria_node_monitor, mria_rlog] : Mod",
+    [{{mria_membership,handle_cast,2}, {mria_rlog,role,1}}]}
  ]}.
 
 {xref_checks,

--- a/rebar.config
+++ b/rebar.config
@@ -22,6 +22,20 @@
 
 {validate_app_modules, true}.
 
+%% Check layer violations (TODO: make it stricter and remove all exemptions):
+{xref_queries,
+ [ {"closure(E) | mria_mnesia : Mod || [mria, mria_lb, mria_schema] : Mod", []}
+ , {"closure(E) | mria_membership : Mod || [mria, mria_lb, mria_schema] : Mod", []}
+ , {"closure(E) | mria_status : Mod || [mria, mria_lb, mria_schema, mria_membership, mria_node_monitor, mria_rlog] : Mod",
+    [{{mria_status,get_shard_lag,1}, {mria_rlog,role,0}},
+     {{mria_status,get_shard_stats,1}, {mria_lb,core_node_weight,1}},
+     {{mria_status,get_shard_stats,1}, {mria_rlog,role,0}},
+     {{mria_status,shards_down,0}, {mria_schema,shards,0}},
+     {{mria_status,shards_status,0}, {mria_schema,shards,0}},
+     {{mria_status,shards_syncing,0}, {mria_schema,shards,0}},
+     {{mria_status,shards_up,0}, {mria_schema,shards,0}}]}
+ ]}.
+
 {xref_checks,
  [undefined_function_calls, undefined_functions,
   locals_not_used, deprecated_function_calls,

--- a/src/mria.erl
+++ b/src/mria.erl
@@ -23,7 +23,7 @@
         ]).
 
 %% Info
--export([info/0, info/1, rocksdb_backend_available/0]).
+-export([info/0, info/1, rocksdb_backend_available/0, running_nodes/0, cluster_nodes/1]).
 
 %% Cluster API
 -export([ join/1
@@ -141,16 +141,59 @@ info(Key) ->
 
 -spec info() -> infos().
 info() ->
-    ClusterInfo = mria_mnesia:cluster_info(),
-    Partitions = mria_node_monitor:partitions(),
-    maps:merge(ClusterInfo,
-               #{ members    => mria_membership:members()
-                , partitions => Partitions
-                , rlog       => mria_rlog:status()
-                }).
+    #{ running_nodes => cluster_nodes(running)
+     , stopped_nodes => cluster_nodes(stopped)
+     , members       => mria_membership:members()
+     , partitions    => mria_node_monitor:partitions()
+     , rlog          => mria_rlog:status()
+     }.
 
 -spec rocksdb_backend_available() -> boolean().
-rocksdb_backend_available() -> ?MRIA_HAS_ROCKSDB.
+rocksdb_backend_available() ->
+    mria_config:rocksdb_backend_available().
+
+%% @doc Cluster nodes.
+-spec cluster_nodes(all | running | stopped | cores) -> [node()].
+cluster_nodes(all) ->
+    Running = running_nodes(),
+    %% Note: stopped replicant nodes won't appear in the list
+    lists:usort(Running ++ db_nodes_maybe_rpc());
+cluster_nodes(running) ->
+    running_nodes();
+cluster_nodes(stopped) ->
+    cluster_nodes(all) -- cluster_nodes(running);
+cluster_nodes(cores) ->
+    case mria_rlog:role() of
+        core ->
+            mria_mnesia:db_nodes();
+        replicant ->
+            mria_lb:core_nodes()
+    end.
+
+%% @doc Running nodes.
+-spec running_nodes() -> list(node()).
+running_nodes() ->
+    %% TODO: cache the results (this could be a hot call) and don't
+    %% fail on the first unsuccessful call, since other nodes may be
+    %% alive. Use info from `mria_membership'?
+    case mria_rlog:role() of
+        core ->
+            CoreNodes = mria_mnesia:running_nodes(),
+            {Replicants0, _} = rpc:multicall(CoreNodes, mria_status, replicants, [], 15000),
+            Replicants = [Node || Nodes <- Replicants0, is_list(Nodes), Node <- Nodes],
+            lists:usort(CoreNodes ++ Replicants);
+        replicant ->
+            case mria_lb:core_nodes() of
+                [CoreNode|_] ->
+                    case mria_lib:rpc_call_nothrow(CoreNode, ?MODULE, running_nodes, []) of
+                        {badrpc, _} -> [];
+                        {badtcp, _} -> [];
+                        Result      -> Result
+                    end;
+                [] ->
+                    []
+            end
+    end.
 
 %%--------------------------------------------------------------------
 %% Cluster API
@@ -168,7 +211,7 @@ join(Node, _) when Node =:= node() ->
 join(Node, Reason) when is_atom(Node) ->
     %% When `Reason =:= heal' the node should rejoin regardless of
     %% what mnesia thinks:
-    IsInCluster = mria_mnesia:is_node_in_cluster(Node) andalso Reason =/= heal,
+    IsInCluster = is_node_in_cluster(Node) andalso Reason =/= heal,
     case {IsInCluster, mria_node:is_running(Node), catch mria_rlog:role(Node)} of
         {false, true, core} ->
             %% FIXME: reading role via `mria_config' may be unsafe
@@ -195,7 +238,7 @@ join(Node, Reason) when is_atom(Node) ->
 %% @doc Leave the cluster
 -spec leave() -> ok | {error, term()}.
 leave() ->
-    case mria_mnesia:running_nodes() -- [node()] of
+    case running_nodes() -- [node()] of
         [_|_] ->
             prep_restart(leave),
             ok = case mria_config:whoami() of
@@ -214,7 +257,7 @@ leave() ->
 force_leave(Node) when Node =:= node() ->
     ignore;
 force_leave(Node) ->
-    case {mria_mnesia:is_node_in_cluster(Node), mria_mnesia:is_running_db_node(Node)} of
+    case {is_node_in_cluster(Node), mria_mnesia:is_running_db_node(Node)} of
         {true, true} ->
             mria_lib:ensure_ok(rpc:call(Node, ?MODULE, leave, []));
         {true, false} ->
@@ -519,3 +562,27 @@ is_upstream(Shard) ->
 prep_restart(Reason) ->
     stop(Reason),
     mria_config:load_config().
+
+
+-spec is_node_in_cluster(node()) -> boolean().
+is_node_in_cluster(Node) ->
+    lists:member(Node, cluster_nodes(all)).
+
+%% TODO: Remove this function and cache the results.
+db_nodes_maybe_rpc() ->
+    case mria_rlog:role() of
+        core ->
+            mria_mnesia:db_nodes();
+        replicant ->
+            case mria_status:shards_up() of
+                [Shard|_] ->
+                    {ok, CoreNode} = mria_status:get_core_node(Shard, 5_000),
+                    case mria_lib:rpc_call_nothrow(CoreNode, mnesia, system_info, [db_nodes]) of
+                        {badrpc, _} -> [];
+                        {badtcp, _} -> [];
+                        Result      -> Result
+                    end;
+                [] ->
+                    []
+            end
+    end.

--- a/src/mria_autoheal.erl
+++ b/src/mria_autoheal.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ handle_msg(Msg = {create_splitview, Node}, Autoheal = #autoheal{delay = Delay, t
     ensure_cancel_timer(TRef),
     case mria_membership:is_all_alive() of
         true ->
-            Nodes = mria_mnesia:cluster_nodes(cores),
+            Nodes = mria_mnesia:db_nodes(),
             case rpc:multicall(Nodes, mria_mnesia, cluster_view, []) of
                 {Views, []} ->
                     SplitView = lists:sort(fun compare_view/2, lists:usort(Views)),

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -48,6 +48,7 @@
         , register_callback/2
         , unregister_callback/1
         , callback/1
+        , rocksdb_backend_available/0
         ]).
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -210,6 +211,10 @@ unregister_callback(Name) ->
 -spec callback(mria_config:callback()) -> {ok, fun(() -> term())} | undefined.
 callback(Name) ->
     apply(application, get_env, [mria, {callback, Name}]).
+
+-spec rocksdb_backend_available() -> boolean().
+rocksdb_backend_available() ->
+    ?MRIA_HAS_ROCKSDB.
 
 %%================================================================================
 %% Internal

--- a/src/mria_membership.erl
+++ b/src/mria_membership.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -280,7 +280,7 @@ handle_cast({node_up, Node}, State) ->
                        [M] -> M#member{status = up};
                        []  -> #member{node = Node, status = up, role = mria_rlog:role(Node)}
                      end,
-            insert(Member#member{mnesia = mria_mnesia:cluster_status(Node)});
+            insert(Member#member{mnesia = mnesia_cluster_status(Node)});
         false -> ignore
     end,
     notify({node, up, Node}, State),
@@ -319,12 +319,12 @@ handle_cast({healing, Node}, State) ->
 handle_cast({ping, Member = #member{node = Node}}, State) ->
     ?tp(mria_membership_ping, #{member => Member}),
     pong(Node, local_member()),
-    insert(Member#member{mnesia = mria_mnesia:cluster_status(Node)}),
+    insert(Member#member{mnesia = mnesia_cluster_status(Node)}),
     {noreply, State};
 
 handle_cast({pong, Member = #member{node = Node}}, State) ->
     ?tp(mria_membership_pong, #{member => Member}),
-    insert(Member#member{mnesia = mria_mnesia:cluster_status(Node)}),
+    insert(Member#member{mnesia = mnesia_cluster_status(Node)}),
     {noreply, State};
 
 handle_cast({leaving, Node}, State) ->
@@ -458,4 +458,13 @@ del_monitor({Type, PidOrFun}, S = #state{monitors = Monitors}) ->
         {_, MRef} ->
             is_pid(PidOrFun) andalso erlang:demonitor(MRef, [flush]),
             S#state{monitors = lists:delete({{Type, PidOrFun}, MRef}, Monitors)}
+    end.
+
+mnesia_cluster_status(Node) ->
+    %% FIXME: ugly workaround. Mnesia status is wrong on the replicant
+    case mria_config:role() of
+        core ->
+            mria_mnesia:cluster_status(Node);
+        replicant ->
+            running
     end.

--- a/src/mria_membership.erl
+++ b/src/mria_membership.erl
@@ -240,7 +240,7 @@ init([]) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => [mria, membership]}),
     _ = ets:new(membership, [ordered_set, protected, named_table, {keypos, 2}]),
-    case mria_rlog:role() of
+    case mria_config:role() of
         core -> initialize_members();
         replicant -> ok
     end,
@@ -402,7 +402,7 @@ make_new_local_member() ->
     with_hash(#member{node = node(), guid = mria_guid:gen(),
                       status = up, mnesia = IsMnesiaRunning,
                       ltime = erlang:timestamp(),
-                      role = mria_rlog:role()
+                      role = mria_config:role()
                      }).
 
 initialize_members() ->

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -142,7 +142,7 @@ connect(Node) ->
 %% @doc Add the node to the cluster schema
 -spec join_cluster(node()) -> ok.
 join_cluster(Node) when Node =/= node() ->
-    case {mria_rlog:role(), mria_rlog:role(Node)} of
+    case {mria_config:role(), mria_rlog:role(Node)} of
         {core, core} ->
             %% Stop mnesia and delete schema first
             mria_lib:ensure_ok(ensure_stopped()),
@@ -251,7 +251,7 @@ copy_table(Name) ->
 
 -spec(copy_table(Name:: atom(), mria:storage()) -> ok).
 copy_table(Name, Storage) ->
-    case mria_rlog:role() of
+    case mria_config:role() of
         core ->
             mria_lib:ensure_tab(mnesia:add_table_copy(Name, node(), Storage));
         replicant ->
@@ -414,7 +414,7 @@ init_schema() ->
                   []    -> true;
                   [_|_] -> false
               end,
-    case (mria_rlog:role() =:= replicant) orelse IsAlone of
+    case (mria_config:role() =:= replicant) orelse IsAlone of
         true ->
             Ret = mnesia:create_schema([node()]),
             ?tp(notice, "Creating new mnesia schema", #{result => Ret}),

--- a/src/mria_mnesia.erl
+++ b/src/mria_mnesia.erl
@@ -111,7 +111,7 @@ ensure_schema() ->
 ensure_started() ->
     ok = mnesia:start(),
     {ok, _} = mria_mnesia_null_storage:register(),
-    case mria:rocksdb_backend_available() of
+    case mria_config:rocksdb_backend_available() of
         true ->
             {ok, _} = application:ensure_all_started(mnesia_rocksdb),
             {ok, _} = mnesia_rocksdb:register();
@@ -196,54 +196,22 @@ cluster_status(Node) ->
 
 -spec(cluster_view() -> {[node()], [node()]}).
 cluster_view() ->
-    list_to_tuple([lists:sort([N || N <- cluster_nodes(Status),
-                                    mria_rlog:role(N) =:= core])
+    list_to_tuple([lists:sort([N || N <- cluster_nodes(Status)])
                    || Status <- [running, stopped]]).
 
 %% @doc Cluster nodes.
 -spec(cluster_nodes(all | running | stopped | cores) -> [node()]).
 cluster_nodes(all) ->
-    Running = running_nodes(),
-    %% Note: stopped replicant nodes won't appear in the list
-    lists:usort(Running ++ db_nodes_maybe_rpc());
+    db_nodes();
 cluster_nodes(running) ->
     running_nodes();
 cluster_nodes(stopped) ->
-    cluster_nodes(all) -- cluster_nodes(running);
-cluster_nodes(cores) ->
-    case mria_rlog:role() of
-        core ->
-            db_nodes();
-        replicant ->
-            mria_lb:core_nodes()
-    end.
+    cluster_nodes(all) -- cluster_nodes(running).
 
 %% @doc Running nodes.
 -spec(running_nodes() -> list(node())).
 running_nodes() ->
-    case mria_rlog:role() of
-        core ->
-            CoreNodes = mnesia:system_info(running_db_nodes),
-            {Replicants0, _} = rpc:multicall(CoreNodes, mria_status, replicants, [], 15000),
-            Replicants = [Node || Nodes <- Replicants0, is_list(Nodes), Node <- Nodes],
-            lists:usort(CoreNodes ++ Replicants);
-        replicant ->
-            case mria_status:shards_up() of
-                [Shard|_] ->
-                    case mria_status:upstream_node(Shard) of
-                        {ok, CoreNode} ->
-                            case mria_lib:rpc_call_nothrow(CoreNode, ?MODULE, running_nodes, []) of
-                                {badrpc, _} -> [];
-                                {badtcp, _} -> [];
-                                Result      -> Result
-                            end;
-                        disconnected ->
-                            []
-                    end;
-                [] ->
-                    []
-            end
-    end.
+    mnesia:system_info(running_db_nodes).
 
 %% @doc List Mnesia DB nodes.  Used by `mria_lb' to check if nodes
 %% reported by core discovery callback are in the same cluster.  This
@@ -253,7 +221,7 @@ db_nodes() ->
 
 %% @doc Is this node in mnesia cluster?
 is_node_in_cluster() ->
-    cluster_nodes(cores) =/= [node()].
+    db_nodes() =/= [node()].
 
 %% @doc Is the node in mnesia cluster?
 -spec(is_node_in_cluster(node()) -> boolean()).
@@ -427,25 +395,6 @@ get_internals() ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
-
-db_nodes_maybe_rpc() ->
-    case mria_rlog:role() of
-        core ->
-            mnesia:system_info(db_nodes);
-        replicant ->
-            case mria_status:shards_up() of
-                [Shard|_] ->
-                    {ok, CoreNode} = mria_status:get_core_node(Shard, 5_000),
-                    case mria_lib:rpc_call_nothrow(CoreNode, mnesia, system_info, [db_nodes]) of
-                        {badrpc, _} -> [];
-                        {badtcp, _} -> [];
-                        Result      -> Result
-                    end;
-                [] ->
-                    []
-            end
-    end.
-
 
 %% @doc Data dir
 -spec(data_dir() -> string()).

--- a/src/mria_node_monitor.erl
+++ b/src/mria_node_monitor.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -340,7 +340,7 @@ apply_schema_op( #?schema{mnesia_table = Table, storage = Storage, shard = Shard
                ) ->
     case lists:keyfind(Table, #?schema.mnesia_table, OldEntries) of
         false -> % new entry
-            Ret = case mria_rlog:role() of
+            Ret = case mria_config:role() of
                       core ->
                           mria_lib:ensure_ok(mria_mnesia:copy_table(Table, Storage));
                       replicant ->

--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -162,7 +162,7 @@ replicants() ->
 
 -spec get_shard_lag(mria_rlog:shard()) -> non_neg_integer() | disconnected.
 get_shard_lag(Shard) ->
-    case {mria_rlog:role(), upstream_node(Shard)} of
+    case {mria_config:role(), upstream_node(Shard)} of
         {core, _} ->
             0;
         {replicant, disconnected} ->
@@ -225,7 +225,7 @@ shards_down() ->
 
 -spec get_shard_stats(mria_rlog:shard()) -> map().
 get_shard_stats(Shard) ->
-    case mria_rlog:role() of
+    case mria_config:role() of
         core ->
             Weight = case mria_lb:core_node_weight(Shard) of
                          undefined          -> undefined;

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1017,7 +1017,13 @@ t_cluster_nodes(_) ->
            [?assertEqual([Core1, Core2], lists:sort(rpc:call(N1, mria, cluster_nodes, [cores])), N1)
             || N1 <- Nodes],
            [?assertEqual([], rpc:call(N1, mria, cluster_nodes, [stopped]), N1)
-            || N1 <- Nodes]
+            || N1 <- Nodes],
+           [?assertMatch(true, rpc:call(N1, mria, is_node_in_cluster, [N2]), {N1, N2})
+            || N1 <- Nodes,
+               N2 <- Nodes],
+           [?assertMatch(running, rpc:call(N1, mria, cluster_status, [N2]), {N1, N2})
+            || N1 <- Nodes,
+               N2 <- Nodes]
        after
            ok = mria_ct:teardown_cluster(Cluster)
        end,

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -182,25 +182,48 @@ t_join_leave_cluster(_) ->
         [N0, N1] = mria_ct:start_cluster(mria, Cluster),
         mria_ct:run_on(N0,
           fun() ->
-                  #{running_nodes := [N0, N1]} = mria_mnesia:cluster_info(),
-                  [N0, N1] = lists:sort(mria_mnesia:running_nodes()),
+                  #{running_nodes := [N0, N1]} = mria:info(),
+                  [N0, N1] = lists:sort(mria:running_nodes()),
                   ok = rpc:call(N1, mria_mnesia, leave_cluster, []),
-                  #{running_nodes := [N0]} = mria_mnesia:cluster_info(),
-                  [N0] = mria_mnesia:running_nodes()
+                  #{running_nodes := [N0]} = mria:info(),
+                  [N0] = mria:running_nodes()
           end)
     after
         ok = mria_ct:teardown_cluster(Cluster)
     end.
 
-t_cluster_status(_) ->
-    Cluster = mria_ct:cluster([core, core], []),
-    try
-        [N0, N1] = mria_ct:start_cluster(mria, Cluster),
-        running = rpc:call(N0, mria_mnesia, cluster_status, [N1]),
-        running = rpc:call(N1, mria_mnesia, cluster_status, [N0])
-    after
-        ok = mria_ct:teardown_cluster(Cluster)
-    end.
+t_cluster_core_nodes_on_replicant(_) ->
+    Cluster = mria_ct:cluster([core, core, replicant], mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       #{timetrap => 30000},
+       try
+           [N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
+           mria_mnesia_test_util:wait_full_replication(Cluster, 15000),
+           ?assertEqual(
+              [N1, N2],
+              erpc:call(N3, mria, cluster_nodes, [cores])),
+           ?assertEqual(
+              [N1, N2, N3],
+              erpc:call(N3, mria, cluster_nodes, [all])),
+           ?assertEqual(
+              [N1, N2, N3],
+              erpc:call(N3, mria, cluster_nodes, [running])),
+           mria_ct:stop_slave(N2),
+           timer:sleep(5000),
+           ?assertEqual(
+              [N1, N2, N3],
+              erpc:call(N3, mria, cluster_nodes, [all])),
+           ?assertEqual(
+              [N2],
+              erpc:call(N3, mria, cluster_nodes, [stopped])),
+           ?assertEqual(
+              [N1, N3],
+              erpc:call(N3, mria, cluster_nodes, [running])),
+           ok
+       after
+           ok = mria_ct:teardown_cluster(Cluster)
+       end,
+       []).
 
 t_remove_from_cluster(_) ->
     Cluster = mria_ct:cluster([core, core, replicant, replicant], mria_mnesia_test_util:common_env()),
@@ -210,19 +233,17 @@ t_remove_from_cluster(_) ->
            [N0, N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
            timer:sleep(1000),
            mria_ct:run_on(N0, fun() ->
-               #{running_nodes := [N0, N1, N2, N3]} = mria_mnesia:cluster_info(),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:running_nodes()),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:cluster_nodes(all)),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:cluster_nodes(running)),
-               [] = mria_mnesia:cluster_nodes(stopped),
+               [N0, N1, N2, N3] = lists:sort(mria:running_nodes()),
+               [N0, N1, N2, N3] = lists:sort(mria:cluster_nodes(all)),
+               [N0, N1, N2, N3] = lists:sort(mria:cluster_nodes(running)),
+               [] = mria:cluster_nodes(stopped),
                ok
              end),
            mria_ct:run_on(N2, fun() ->
-               #{running_nodes := [N0, N1, N2, N3]} = mria_mnesia:cluster_info(),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:running_nodes()),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:cluster_nodes(all)),
-               [N0, N1, N2, N3] = lists:sort(mria_mnesia:cluster_nodes(running)),
-               [] = mria_mnesia:cluster_nodes(stopped),
+               [N0, N1, N2, N3] = lists:sort(mria:running_nodes()),
+               [N0, N1, N2, N3] = lists:sort(mria:cluster_nodes(all)),
+               [N0, N1, N2, N3] = lists:sort(mria:cluster_nodes(running)),
+               [] = mria:cluster_nodes(stopped),
                ok
              end),
            {ok, SubRef} = snabbkaffe:subscribe(
@@ -232,8 +253,8 @@ t_remove_from_cluster(_) ->
                                           })),
            mria_ct:run_on(N0, fun() ->
                ok = mria:force_leave(N1),
-               Running = mria_mnesia:running_nodes(),
-               All = mria_mnesia:cluster_nodes(all),
+               Running = mria:running_nodes(),
+               All = mria:cluster_nodes(all),
                ?assertNot(lists:member(N1, Running)),
                ?assertNot(lists:member(N1, All)),
                ?assertNot(mria_membership:is_member(N1))

--- a/test/mria_membership_SUITE.erl
+++ b/test/mria_membership_SUITE.erl
@@ -40,6 +40,7 @@ init_per_testcase(_TestCase, Config) ->
     Config.
 
 end_per_testcase(_TestCase, Config) ->
+    snabbkaffe:stop(),
     ok = mria_membership:stop(),
     ok = meck:unload(mria_mnesia),
     Config.


### PR DESCRIPTION
Background:
Some time ago EMQX started using `mria_mnesia:running_nodes()` function instead of `erlang:nodes()` to avoid RPC'ing to remote shell nodes and other non-EMQX nodes that may appear in the cluster.
It required adding replicant nodes to the output of that function. I didn't think hard enough about the ramifications of such decision and went ahead with it. It created some nasty circular dependencies between the processes, that manifest themselves during restarts or cluster healing or joining.
This PR restores some sanity to the call graph. 
1) `mria_mnesia` no longer knows anything about RLOG processes
2) `mria_membership` no longer calls RLOG processes
3) Added some XREF checks to avoid future problems; they can be improved.