### PR TITLE
feat: implement mria:sync_transaction/4,3,2

### DIFF
--- a/src/mria_membership.erl
+++ b/src/mria_membership.erl
@@ -213,7 +213,7 @@ is_all_alive() ->
 
 -spec(is_running() -> boolean()).
 is_running() ->
-     is_pid(whereis(?MODULE)).
+    is_pid(whereis(?MODULE)).
 
 -spec(monitor(event_type(), pid() | function(), boolean()) -> ok).
 monitor(Type, PidOrFun, OnOff) ->
@@ -372,7 +372,7 @@ handle_cast({pong, Member}, State) ->
     ?tp(mria_membership_pong, #{member => Member}),
     {Member1, State1} = monitor_if_replicant(Member, State),
     insert(Member1),
-   {noreply, State1};
+    {noreply, State1};
 
 handle_cast({leaving, Node}, State) ->
     ?LOG(info, "Node ~s leaving", [Node]),

--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -29,6 +29,7 @@
 -export([ set_initial_seqno/2
         , import_batch/3
         , start_link/2
+        , name/1
         ]).
 
 %% gen_server callbacks
@@ -65,6 +66,10 @@ import_batch(ImportType, Server, Tx) ->
 set_initial_seqno(Server, SeqNo) ->
     gen_server:call(Server, {set_initial_seqno, SeqNo}).
 
+-spec name(mria_rlog:shard()) -> atom().
+name(Shard) ->
+    list_to_atom(atom_to_list(Shard) ++ "_importer_worker").
+
 %%================================================================================
 %% gen_server callbacks
 %%================================================================================
@@ -76,7 +81,7 @@ init([Shard, SeqNo]) ->
                                  }),
     ?tp(mria_replica_importer_worker_start, #{shard => Shard, seqno => SeqNo}),
     State = #s{shard = Shard, seqno = SeqNo},
-    register(list_to_atom(atom_to_list(Shard) ++ "_importer_worker"), self()),
+    register(name(Shard), self()),
     {ok, State}.
 
 handle_call(Call, From, St) ->
@@ -122,7 +127,8 @@ do_import_batch_dirty(Batch) ->
                               #{ tid => _TID
                                , ops => Ops
                                }),
-                          lists:foreach(fun import_op_dirty/1, Ops)
+                          Waiting = lists:foldr(fun import_op_dirty/2, [], Ops),
+                          maybe_reply_awaiting_dirty(Waiting)
                   end,
                   Batch).
 
@@ -133,8 +139,14 @@ import_batch(L = [{TID, _Ops}|_]) when ?IS_DIRTY(TID) ->
     Rest = mnesia:async_dirty(fun do_import_batch/2, [dirty, L]),
     import_batch(Rest);
 import_batch(L = [{TID, _Ops}|_]) when ?IS_TRANS(TID) ->
-    {atomic, Rest} = mnesia:transaction(fun do_import_batch/2, [transaction, L]),
-    import_batch(Rest).
+    {atomic, Res} = mnesia:transaction(fun do_import_batch/2, [transaction, L]),
+    Rest1 = case Res of
+                {#?rlog_sync{reply_to = Alias}, Rest} ->
+                    Alias ! {done, Alias},
+                    Rest;
+                _ -> Res
+            end,
+    import_batch(Rest1).
 
 -spec do_import_batch(dirty | transaction, [mria_rlog:tx()]) -> [mria_rlog:tx()].
 do_import_batch(dirty, [{TID, Ops} | Rest]) when ?IS_DIRTY(TID) ->
@@ -142,42 +154,85 @@ do_import_batch(dirty, [{TID, Ops} | Rest]) when ?IS_DIRTY(TID) ->
         #{ tid => TID
          , ops => Ops
          }),
-    lists:foreach(fun import_op_dirty/1, Ops),
+    Waiting = lists:foldr(fun import_op_dirty/2, [], Ops),
+    maybe_reply_awaiting_dirty(Waiting),
     do_import_batch(dirty, Rest);
 do_import_batch(transaction, [{TID, Ops} | Rest]) when ?IS_TRANS(TID) ->
     ?tp(rlog_import_trans,
         #{ tid => TID
          , ops => Ops
          }),
-    lists:foreach(fun import_op/1, Ops),
-    do_import_batch(transaction, Rest);
+    Waiting = lists:foldr(fun import_op/2, [], Ops),
+    %% Whenever we encounter synchronous transaction initiated by this node,
+    %% we stop the iteration, so that an initial caller waiting for a reply
+    %% is notified ASAP without waiting for the whole batch to be committed.
+    case Waiting of
+        [] -> do_import_batch(transaction, Rest);
+        [ReplyTo] -> {ReplyTo, Rest};
+        [ReplyTo | _] = L ->
+            %% One transaction has (and must be awaited by) only one caller.
+            %% More than one may happen if someone additionally calls
+            %% mnesia:write(#?rlog_sync{} = ReplyTo) inside a transaction.
+            ?unexpected_event_tp(#{sync_trans_reply_to => L}),
+            {ReplyTo, Rest}
+    end;
 do_import_batch(_, L) ->
     L.
 
--spec import_op(mria_rlog:op()) -> ok.
-import_op(Op) ->
+-spec import_op(mria_rlog:op(), list()) -> list().
+import_op(Op, Acc) ->
     case Op of
+        {write, ?rlog_sync, ReplyTo} ->
+            maybe_add_reply(ReplyTo, Acc);
         {write, Tab, Rec} ->
-            mnesia:write(Tab, Rec, write);
+            mnesia:write(Tab, Rec, write),
+            Acc;
         {delete, Tab, Key} ->
-            mnesia:delete({Tab, Key});
+            mnesia:delete({Tab, Key}),
+            Acc;
         {delete_object, Tab, Rec} ->
-            mnesia:delete_object(Tab, Rec, write);
+            mnesia:delete_object(Tab, Rec, write),
+            Acc;
         {clear_table, Tab} ->
-            mria_mnesia:clear_table_int(Tab)
+            mria_mnesia:clear_table_int(Tab),
+            Acc
     end.
 
--spec import_op_dirty(mria_rlog:op()) -> ok.
-import_op_dirty(Op) ->
+-spec import_op_dirty(mria_rlog:op(), list()) -> ok.
+import_op_dirty(Op, Acc) ->
     case Op of
+        {write, ?rlog_sync, ReplyTo} ->
+            maybe_add_reply(ReplyTo, Acc);
         {write, Tab, Rec} ->
-            mnesia:dirty_write(Tab, Rec);
+            mnesia:dirty_write(Tab, Rec),
+            Acc;
         {delete, Tab, Key} ->
-            mnesia:dirty_delete({Tab, Key});
+            mnesia:dirty_delete({Tab, Key}),
+            Acc;
         {delete_object, Tab, Rec} ->
-            mnesia:dirty_delete_object(Tab, Rec);
+            mnesia:dirty_delete_object(Tab, Rec),
+            Acc;
         {update_counter, Tab, Key, Incr} ->
-            mnesia:dirty_update_counter(Tab, Key, Incr);
+            mnesia:dirty_update_counter(Tab, Key, Incr),
+            Acc;
         {clear_table, Tab} ->
-            mnesia:clear_table(Tab)
+            mnesia:clear_table(Tab),
+            Acc
     end.
+
+maybe_add_reply(#?rlog_sync{reply_to = Alias} = ReplyTo, Acc)
+  when node(Alias) =:= node() ->
+    ?tp(importer_worker_sync_trans_recv, #{reply_to => Alias}),
+    [ReplyTo | Acc];
+maybe_add_reply(_ReplyTo, Acc) ->
+    Acc.
+
+maybe_reply_awaiting_dirty([]) ->
+    ok;
+maybe_reply_awaiting_dirty([#?rlog_sync{reply_to = Alias} | T] = L) ->
+    %% We can reply right here inside a dirty activity context,
+    %% at this point, all operations of a given transaction have
+    %% been applied, so it's safe to reply to an awaiting process (if any).
+    T =/= [] andalso ?unexpected_event_tp(#{sync_trans_reply_to => L}),
+    Alias ! {done, Alias},
+    ok.

--- a/src/mria_rlog.hrl
+++ b/src/mria_rlog.hrl
@@ -3,7 +3,7 @@
 
 -define(mria_meta_shard, '$mria_meta_shard').
 -define(schema, mria_schema).
--define(rlog_sync, mria_rlog_sync).
+-define(rlog_sync, '$mria_rlog_sync').
 
 %% Note to self: don't forget to update all the match specs in
 %% `mria_schema' module when changing fields in this record

--- a/src/mria_rlog.hrl
+++ b/src/mria_rlog.hrl
@@ -3,6 +3,7 @@
 
 -define(mria_meta_shard, '$mria_meta_shard').
 -define(schema, mria_schema).
+-define(rlog_sync, mria_rlog_sync).
 
 %% Note to self: don't forget to update all the match specs in
 %% `mria_schema' module when changing fields in this record
@@ -12,6 +13,8 @@
         , storage
         , config
         }).
+
+-record(?rlog_sync, {reply_to, shard}).
 
 -define(LOCAL_CONTENT_SHARD, undefined).
 

--- a/src/mria_rlog_replica.erl
+++ b/src/mria_rlog_replica.erl
@@ -315,6 +315,11 @@ handle_importer_ack(State, Ack, Data) ->
 -spec initiate_reconnect(data()) -> fsm_result().
 initiate_reconnect(D0 = #d{shard = Shard, parent_sup = SupPid, importer_ref = Ref}) ->
     mria_status:notify_shard_down(Shard),
+    %% IMPORTANT: mria:sync_transaction/4,3,2 relies on the fact that
+    %% importer_worker is restarted whenever something goes wrong,
+    %% e.g, when an agent on a core node is down and mria_rlog_replica reconnects.
+    %% If this behavior is ever changed, mria:sync_transaction/4,3,2 implementation
+    %% needs to be updated accordingly (this is also covered by a test case).
     mria_replicant_shard_sup:stop_importer_worker(SupPid),
     flush_importer_acks(Ref),
     D1 = close_replayq(D0),

--- a/src/mria_schema.erl
+++ b/src/mria_schema.erl
@@ -330,8 +330,7 @@ boostrap() ->
     %% Create (or copy) the mnesia table and wait for it:
     ok = create_table(MetaSpec),
     ok = mria_mnesia:copy_table(?schema, Storage),
-    RlogSyncOpts = [{type, set},
-                    {record_name, ?rlog_sync},
+    RlogSyncOpts = [{record_name, ?rlog_sync},
                     {attributes, record_info(fields, ?rlog_sync)}
                    ],
     RlogSyncSpec = #?schema{ mnesia_table = ?rlog_sync
@@ -340,7 +339,6 @@ boostrap() ->
                            , config = RlogSyncOpts
                            },
     ok = create_table(RlogSyncSpec),
-    %% TODO: is it needed?
     ok = mria_mnesia:copy_table(?rlog_sync, Storage),
     mria_mnesia:wait_for_tables([?schema, ?rlog_sync]),
     %% Seed the table with the metadata:

--- a/src/mria_upstream.erl
+++ b/src/mria_upstream.erl
@@ -26,7 +26,6 @@
 %% API:
 %% Internal exports
 -export([ transactional_wrapper/3
-        , sync_transactional_wrapper/4
         , sync_dummy_wrapper/2
         , dirty_wrapper/4
         , dirty_write_sync/2
@@ -51,23 +50,6 @@ transactional_wrapper(Shard, Fun, Args) ->
     mria_rlog:wait_for_shards([Shard], infinity),
     mnesia:transaction(fun() ->
                                Res = apply(Fun, Args),
-                               {_TID, TxStore} = mria_mnesia:get_internals(),
-                               ensure_no_ops_outside_shard(TxStore, Shard, OldServerPid),
-                               Res
-                       end).
-
-%% @doc Performs a transaction and writes a special ReplyTo record to rlog_sync
-%% (null_copies table) that will be replicated to the replicant node and used to notify
-%% the initial caller when the transaction is replicated locally.
--spec sync_transactional_wrapper(mria_rlog:shard(), fun(), list(), mria_rlog:sync_reply_to()) ->
-          mria:t_result(term()).
-sync_transactional_wrapper(Shard, Fun, Args, ReplyTo) ->
-    OldServerPid = whereis(Shard),
-    ensure_no_transaction(),
-    mria_rlog:wait_for_shards([Shard], infinity),
-    mnesia:transaction(fun() ->
-                               Res = apply(Fun, Args),
-                               ok = mnesia:write(ReplyTo),
                                {_TID, TxStore} = mria_mnesia:get_internals(),
                                ensure_no_ops_outside_shard(TxStore, Shard, OldServerPid),
                                Res

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -426,9 +426,9 @@ t_sync_transaction_on_replicant(_) ->
                      ?of_node(N2, Trace)
                     )
                  ),
-               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_timeout, ?of_node(N2, Trace))),
-               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_down, ?of_node(N2, Trace))),
-               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_aborted, ?of_node(N2, Trace))),
+               ?assertMatch([_], ?of_kind(mria_replicant_sync_trans_timeout, ?of_node(N2, Trace))),
+               ?assertMatch([_], ?of_kind(mria_replicant_sync_trans_down, ?of_node(N2, Trace))),
+               ?assertMatch([_], ?of_kind(mria_replicant_sync_trans_aborted, ?of_node(N2, Trace))),
                %% check that no replies were attempted to be send from another replicant node,
                %% that didn't initiated any sync transactions
                ?assertEqual([], ?of_kind(importer_worker_sync_trans_recv, ?of_node(N3, Trace)))

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -359,6 +359,81 @@ t_transaction_on_replicant(_) ->
                mria_rlog_props:no_unexpected_events(Trace)
        end).
 
+t_sync_transaction_on_replicant(_) ->
+    Cluster = mria_ct:cluster([core, replicant, replicant], mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       try
+           Nodes = [N1, N2, _N3] = mria_ct:start_cluster(mria, Cluster),
+           mria_mnesia_test_util:wait_tables(Nodes),
+           [?assertEqual({atomic,[]},
+                         rpc:call(N, mnesia, transaction, [fun() -> mnesia:all_keys(test_tab) end]))
+            || N <- Nodes],
+           K1 = V1 = <<"sync1">>,
+           ExpectedR1 = {test_tab, K1, V1},
+           K2 = V2 = <<"sync2">>,
+           ExpectedR2 = {test_tab, K2, V2},
+           K3 = V3 = <<"sync3">>,
+           ExpectedR3 = {test_tab, K3, V3},
+           K4 = V4 = <<"sync4">>,
+           ExpectedR4 = {test_tab, K4, V4},
+           %% Happy path scenario
+           ?ON(N2,
+               begin
+                   ?assertEqual({atomic, ok},
+                                mria:sync_transaction(test_shard, fun() -> mnesia:write(ExpectedR1) end)),
+                   ?assertEqual({atomic, [ExpectedR1]},
+                                mnesia:transaction(fun() -> mnesia:read(test_tab, K1) end))
+               end),
+           %% Aborted transaction
+           ?assertMatch({aborted, _},
+                        rpc:call(N2, mria, sync_transaction,
+                                 [test_shard, fun() -> mnesia:write(ExpectedR1), mnesia:abort(test) end])),
+           %% Failure during transaction
+           SlowTransFun = fun() -> timer:sleep(7000), mnesia:write(ExpectedR2), mnesia:read(test_tab, K2) end,
+           {ok, AgentPid} = rpc:call(N2, mria_status, upstream, [test_shard]),
+           ReqKey = rpc:async_call(N2, mria, sync_transaction, [test_shard, SlowTransFun]),
+           true = rpc:call(N1, erlang, exit, [AgentPid, kill]),
+           SlowTransRes = rpc:yield(ReqKey),
+           SlowTransResRepl = rpc:call(N2, mnesia, transaction, [fun() -> mnesia:read(test_tab, K2) end]),
+           ?assertEqual({atomic, [ExpectedR2]}, SlowTransRes),
+           ?assertEqual({atomic, [ExpectedR2]}, SlowTransResRepl),
+           %% Timeout happy path
+           ?ON(N2,
+               begin
+                   ?assertEqual({atomic, ok},
+                                mria:sync_transaction(test_shard,
+                                                      fun() -> mnesia:write(ExpectedR3) end, [], 5000)),
+                   ?assertEqual({atomic, [ExpectedR3]},
+                                mnesia:transaction(fun() -> mnesia:read(test_tab, K3) end))
+               end),
+           %% Timeout
+           ?force_ordering(#{?snk_kind := mria_replicant_sync_trans_timeout, reply_to := _Alias1},
+                           #{?snk_kind := importer_worker_sync_trans_recv, reply_to := _Alias2},
+                           _Alias1 =:= _Alias2),
+           TimeoutFun = fun() -> mnesia:write(ExpectedR4), mnesia:read(test_tab, K4) end,
+           TimeoutRpc = rpc:call(N2, mria, sync_transaction, [test_shard, TimeoutFun, [], 10]),
+           ?assertEqual({timeout, {atomic, [ExpectedR4]}}, TimeoutRpc),
+           Nodes
+       after
+           mria_ct:teardown_cluster(Cluster)
+       end,
+       fun([_N1, N2, N3], Trace) ->
+               ?assert(
+                  ?causality(
+                     #{?snk_kind := importer_worker_sync_trans_recv, reply_to := _AliasRecv},
+                     #{?snk_kind := mria_replicant_sync_trans_done, reply_to := _AliasDone},
+                     _AliasRecv =:= _AliasDone,
+                     ?of_node(N2, Trace)
+                    )
+                 ),
+               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_timeout, ?of_node(N2, Trace))),
+               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_down, ?of_node(N2, Trace))),
+               ?assertMatch([_|[]], ?of_kind(mria_replicant_sync_trans_aborted, ?of_node(N2, Trace))),
+               %% check that no replies were attempted to be send from another replicant node,
+               %% that didn't initiated any sync transactions
+               ?assertEqual([], ?of_kind(importer_worker_sync_trans_recv, ?of_node(N3, Trace)))
+       end).
+
 %% Check that behavior on error and exception is the same for both backends
 t_abort(_) ->
     Cluster = mria_ct:cluster([core, replicant], mria_mnesia_test_util:common_env()),


### PR DESCRIPTION
When called on a replicant node, this function blocks a caller process until the transaction is replicated on that node or a timeout occurs. Otherwise, it behaves the same way as mria:transaction/3,2

Closes: EMQX-9102