### PR TITLE
fix(mria_membership): call `mria_rlog:role/1` safely

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,8 @@
  , {"closure(E) | mria_mnesia : Mod || [mria, mria_lb, mria_schema, mria_node_monitor, mria_membership, mria_rlog] : Mod",
     [{{mria_mnesia,join_cluster,1}, {mria_rlog,role,1}}]}
  , {"closure(E) | mria_membership : Mod || [mria, mria_lb, mria_schema, mria_node_monitor, mria_rlog] : Mod",
-    [{{mria_membership,handle_cast,2}, {mria_rlog,role,1}}]}
+    [{{mria_membership,handle_cast,2}, {mria_rlog,role,1}},
+     {{mria_membership,role,1},{mria_rlog,role,1}}]}
  ]}.
 
 {xref_checks,


### PR DESCRIPTION
This ensures mria_membership won't crash if RPC to another node fails.