### PR TITLE
chore: bump `mnesia_rocksdb` -> 0.1.14

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -10,15 +10,14 @@ jobs:
         strategy:
           matrix:
             os:
-              - ubuntu20.04
+              - ubuntu22.04
             otp:
-              - 24.3.4.2-3
-              - 25.1.2-3
+              - 25.3.2-1
             elixir:
-              - 1.13.4
+              - 1.14.5
             arch:
               - amd64
-        container: ghcr.io/emqx/emqx-builder/5.0-33:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+        container: ghcr.io/emqx/emqx-builder/5.1-3:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
         steps:
         - uses: actions/checkout@v1

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
  [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.7"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.0.1"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
-  {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.13"}}},
+  {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.14"}}},
   {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.4"}}}
  ]}.
 


### PR DESCRIPTION
https://github.com/emqx/erlang-rocksdb/releases/tag/1.8.0-emqx-1

will tag 0.5.8