### PR TITLE
fix(status): don't subtract `undefined` when calculating shard lag

### DIFF
--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -179,12 +179,13 @@ get_shard_lag(Shard) ->
         {replicant, disconnected} ->
             disconnected;
         {replicant, {ok, Upstream}} ->
-            case erpc:call(Upstream, ?MODULE, get_stat, [Shard, ?core_intercept], 1000) of
-                undefined ->
-                    0;
-                RemoteSeqNo ->
-                    MySeqNo = get_stat(Shard, ?replicant_import),
-                    RemoteSeqNo - MySeqNo
+            RemoteSeqNo = erpc:call(Upstream, ?MODULE, get_stat, [Shard, ?core_intercept], 1000),
+            MySeqNo = get_stat(Shard, ?replicant_import),
+            case is_number(RemoteSeqNo) andalso is_number(MySeqNo) of
+                true ->
+                    RemoteSeqNo - MySeqNo;
+                false ->
+                    0
             end
     end.
 


### PR DESCRIPTION
```
Run stage failed: error:{exception,badarith,
                            [{erlang,'-',
                                 [5,undefined],
                                 [{error_info,#{module => erl_erts_errors}}]},
                             {mria_status,get_shard_lag,1,
                                 [{file,"/__w/mria/mria/src/mria_status.erl"},
                                  {line,187}]},
                             {mria_status,get_shard_stats,1,
                                 [{file,"/__w/mria/mria/src/mria_status.erl"},
                                  {line,256}]},
                             {mria_rlog,'-status/0-lc$^0/1-0-',1,
                                 [{file,"/__w/mria/mria/src/mria_rlog.erl"},
                                  {line,99}]},
                             {mria_rlog,status,0,
                                 [{file,"/__w/mria/mria/src/mria_rlog.erl"},
                                  {line,100}]},
                             {mria,info,0,
                                 [{file,"/__w/mria/mria/src/mria.erl"},
                                  {line,157}]},
                             {mria,do_join,3,
                                 [{file,"/__w/mria/mria/src/mria.erl"},
                                  {line,606}]},
                             {global,trans,4,
                                 [{file,"global.erl"},{line,477}]}]}
```
https://github.com/emqx/mria/actions/runs/6201007103/job/16836825159?pr=160#step:10:19086