### PR TITLE
chore: reduce diagnosts config check log level

### DIFF
--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -282,9 +282,7 @@ consistency_check() ->
         true ->
             ok;
         false ->
-            ?LOG(warning, "Configuration error: extra mnesia diagnostic "
-                          "checks must be of type [{any(), any(), fun(() -> any())}]; "
-                          "double-check `extra_mnesia_diagnostic_checks'", []),
+            ?LOG(warning, "Some unknown mnesia diagnostic checks are ignored", []),
             ok
     end.
 

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -282,9 +282,9 @@ consistency_check() ->
         true ->
             ok;
         false ->
-            ?LOG(critical, "Configuration error: extra mnesia diagnostic "
-                           "checks must be of type [{any(), any(), fun(() -> any())}]; "
-                           "double-check `extra_mnesia_diagnostic_checks'", []),
+            ?LOG(warning, "Configuration error: extra mnesia diagnostic "
+                          "checks must be of type [{any(), any(), fun(() -> any())}]; "
+                          "double-check `extra_mnesia_diagnostic_checks'", []),
             ok
     end.
 


### PR DESCRIPTION
Since this is a hidden, optional configuration that doesn't affect normal operations, users shouldn't be alarmed by a misconfiguration.