### PR TITLE
chore: upgrade to mnesia_rocksdb 0.1.15 for OTP 26 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
  [{snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.7"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.0"}}},
   {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.6"}}},
-  {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.14"}}},
+  {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.15"}}},
   {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.5"}}}
  ]}.
 


### PR DESCRIPTION
upgrade:
- mnesia_rocksdb to `0.1.15`
   - erlang-rocksdb to `1.8.0-emqx-2`