### PR TITLE
check that Mnesia supports match_delete/2

### DIFF
--- a/src/mria_replica_importer_worker.erl
+++ b/src/mria_replica_importer_worker.erl
@@ -223,6 +223,11 @@ import_op_dirty(Op, Acc) ->
             mnesia:clear_table(Tab),
             Acc;
         {clear_table, Tab, Pattern} ->
+            %% If this op is received, we assume that this node also has
+            %% `mnesia:match_delete/2.
+            %% As mria protocol has been bumped, during rolling updates
+            %% new replicants must connect only to new cores,
+            %% so that both should have this new function.
             mnesia:match_delete(Tab, Pattern),
             Acc
     end.


### PR DESCRIPTION
The check is done on a local node, assuming that all nodes in the cluster run the same OTP/Mnesia.