### PR TITLE
fix(membership): leader calculation error in some cases

### DIFF
--- a/src/mria_membership.erl
+++ b/src/mria_membership.erl
@@ -183,6 +183,10 @@ oldest(Members) ->
     hd(lists:sort(fun compare/2, Members)).
 
 %% @private
+compare(#member{guid = undefined}, #member{guid = _}) ->
+    false;
+compare(#member{guid = _}, #member{guid = undefined}) ->
+    true;
 compare(M1, M2) ->
     M1#member.guid < M2#member.guid.
 


### PR DESCRIPTION
For example, if a node has just joined the cluster, but has not fully rebooted successfully, its `guid` is undefined:

```
[{member,'emqx@10.42.3.236',undefined,
    <<0,6,15,187,202,198,177,159,90,134,0,0,11,232,
      0,0>>,
    3792610979,up,running,
    {1706,149095,584199},
    core},
  {member,'emqx@10.42.6.225',undefined,undefined,
   undefined,up,running,
   {1706,155167,852643},
   core}]
```