### PR TITLE
feat: add API to disable/enable core node discovery

### DIFF
--- a/src/mria.erl
+++ b/src/mria.erl
@@ -35,6 +35,8 @@
         , cluster_nodes/1
         , cluster_status/1
         , is_node_in_cluster/1
+        , enable_core_node_discovery/0
+        , disable_core_node_discovery/0
         ]).
 
 %% Register callback
@@ -270,6 +272,14 @@ force_leave(Node) ->
         {false, _} ->
             {error, node_not_in_cluster}
     end.
+
+-spec enable_core_node_discovery() -> ok.
+enable_core_node_discovery() ->
+    mria_config:set_core_node_discovery(true).
+
+-spec disable_core_node_discovery() -> ok.
+disable_core_node_discovery() ->
+    mria_config:set_core_node_discovery(false).
 
 %%--------------------------------------------------------------------
 %% Register callback

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -32,6 +32,9 @@
         , load_config/0
         , erase_all_config/0
 
+        , set_core_node_discovery/1
+        , is_core_node_discovery_enabled/0
+
           %% Shard config:
         , set_dirty_shard/2
         , dirty_shard/1
@@ -246,6 +249,22 @@ set_extra_mnesia_diagnostic_checks(Checks) when is_list(Checks) ->
 -spec get_extra_mnesia_diagnostic_checks() -> [{_Name, Value, fun(() -> Value)}].
 get_extra_mnesia_diagnostic_checks() ->
     persistent_term:get(?mria(extra_mnesia_diagnostic_checks), []).
+
+-spec set_core_node_discovery(boolean()) -> ok.
+set_core_node_discovery(What) when What =:= true; What =:= false ->
+    case role() of
+        core ->
+            ok;
+        replicant ->
+            ok = application:set_env(mria, core_node_discovery, What)
+    end.
+
+-spec is_core_node_discovery_enabled() -> boolean().
+is_core_node_discovery_enabled() ->
+    case role() of
+        core -> false;
+        replicant -> application:get_env(mria, core_node_discovery, true)
+    end.
 
 %%================================================================================
 %% Internal

--- a/src/mria_lb.erl
+++ b/src/mria_lb.erl
@@ -314,11 +314,16 @@ lb_callback() ->
 
 -spec discover_nodes() -> [node()].
 discover_nodes() ->
-    DiscoveryFun = mria_config:core_node_discovery_callback(),
     case manual_seed() of
         [] ->
-            %% Run the discovery algorithm
-            DiscoveryFun();
+            case mria_config:is_core_node_discovery_enabled() of
+                true ->
+                    %% Run the discovery algorithm
+                    DiscoveryFun = mria_config:core_node_discovery_callback(),
+                    DiscoveryFun();
+                false ->
+                    []
+            end;
         [Seed] ->
             discover_manually(Seed)
     end.


### PR DESCRIPTION
This can be used to prevent a replicant node from re-joining the same cluster after it has (manually) left the cluster but still can discover and reach cluster nodes.

EMQX PR: https://github.com/emqx/emqx/pull/12799