### PR TITLE
fix(rpc): Follow-up to the previous fix

### DIFF
--- a/src/mria.erl
+++ b/src/mria.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -595,7 +595,7 @@ should_retry_rpc(_) ->
 find_upstream_node(Shard) ->
     ?tp_span(find_upstream_node, #{shard => Shard},
              begin
-                 {ok, Node} = mria_status:get_core_node(Shard, infinity),
+                 {ok, Node} = mria_status:rpc_target(Shard, infinity),
                  Node
              end).
 
@@ -688,7 +688,7 @@ db_nodes_maybe_rpc() ->
         replicant ->
             case mria_status:shards_up() of
                 [Shard|_] ->
-                    {ok, CoreNode} = mria_status:get_core_node(Shard, 5_000),
+                    {ok, CoreNode} = mria_status:rpc_target(Shard, 5_000),
                     case mria_lib:rpc_call_nothrow(CoreNode, mnesia, system_info, [db_nodes]) of
                         {badrpc, _} -> [];
                         {badtcp, _} -> [];

--- a/src/mria.erl
+++ b/src/mria.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -595,7 +595,7 @@ should_retry_rpc(_) ->
 find_upstream_node(Shard) ->
     ?tp_span(find_upstream_node, #{shard => Shard},
              begin
-                 {ok, Node} = mria_status:upstream_node(Shard, infinity),
+                 {ok, Node} = mria_status:get_core_node(Shard, infinity),
                  Node
              end).
 
@@ -688,7 +688,7 @@ db_nodes_maybe_rpc() ->
         replicant ->
             case mria_status:shards_up() of
                 [Shard|_] ->
-                    {ok, CoreNode} = mria_status:upstream_node(Shard, 5_000),
+                    {ok, CoreNode} = mria_status:get_core_node(Shard, 5_000),
                     case mria_lib:rpc_call_nothrow(CoreNode, mnesia, system_info, [db_nodes]) of
                         {badrpc, _} -> [];
                         {badtcp, _} -> [];

--- a/test/concuerror_tests.erl
+++ b/test/concuerror_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ get_core_node_test() ->
         spawn(fun() ->
                       catch mria_status:notify_core_node_up(foo, Node)
               end),
-        ?assertMatch({ok, Node}, mria_status:get_core_node(foo, infinity)),
+        ?assertMatch({ok, Node}, mria_status:replica_get_core_node(foo, infinity)),
         ?assertMatch([], flush())
     after
         cleanup()

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -863,9 +863,6 @@ t_sum_verify(_) ->
     ?check_trace(
        #{timetrap => 30000},
        try
-           ?force_ordering( #{?snk_kind := verify_trans_step, n := N} when N =:= NTrans div 4
-                          , #{?snk_kind := state_change, to := bootstrap, shard := test_shard}
-                          ),
            ?force_ordering( #{?snk_kind := verify_trans_step, n := N} when N =:= 2 * NTrans div 4
                           , #{?snk_kind := state_change, to := local_replay, shard := test_shard}
                           ),

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021, 2023-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -283,7 +283,7 @@ t_custom_compat_check(_Config) ->
            [_C1, _C2, C3, R1] = mria_ct:start_cluster(mria, Cluster),
            ?assertEqual({ok, C3},
                         erpc:call( R1
-                                 , mria_status, get_core_node, [?mria_meta_shard, infinity]
+                                 , mria_status, replica_get_core_node, [?mria_meta_shard, infinity]
                                  , infinity
                                  ))
        after


### PR DESCRIPTION
Introduce a new optvar for RPC targeting instead of trying to reuse others.
