### PR TITLE
fix: run middleman through spawn_monitor/1

### DIFF
--- a/src/mria_lib.erl
+++ b/src/mria_lib.erl
@@ -129,7 +129,7 @@ unwrap_exception({EC, Err, Stack}) when EC =:= error;
     TopStack = try error(dummy) catch _:_:ST -> ST end,
     erlang:raise(EC, Err, Stack ++ TopStack);
 unwrap_exception(Other) ->
-    error(Other).
+    exit(Other).
 
 -spec wrap_exception(module(), atom(), list()) -> {ok, term()} | {error | exit | throw, _Reason, _Stack :: list()}.
 wrap_exception(Mod, Fun, Args) ->


### PR DESCRIPTION
This way we avoid polluting message queue of the calling process with `{'EXIT', ..., normal}` messages in case when the calling process is trapping exits.

Selective receive optimization is preserved.
```
src/mria.erl:543: OPTIMIZED: reference used to mark a message queue position
src/mria.erl:551: OPTIMIZED: all clauses match reference created by spawn_monitor/1 at ws/emqx/mria/src/mria.erl:543
```