### PR TITLE
fix(status): unset optvars properly on terminate

### DIFF
--- a/src/mria_status.erl
+++ b/src/mria_status.erl
@@ -355,7 +355,7 @@ init(_) ->
 
 terminate(_Reason, _State) ->
     ?terminate_tp,
-    [optvar:unset(K) || ?optvar(K) <- optvar:list()],
+    [optvar:unset(?optvar(K)) || ?optvar(K) <- optvar:list()],
     {exit, normal}.
 
 handle_call(_, _, State) ->


### PR DESCRIPTION
Previously `mria_status` attempted unsetting wrong optvars not wrapped in `{mria, KEY}` tuple, which have caused status optvars to survive application restart. This PR fixes it.