### PR TITLE
test: prepare for the ram_copies table fix in otp

### DIFF
--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1235,10 +1235,10 @@ t_cluster_nodes(_) ->
        []).
 
 %% This testcase verifies that nodes don't get stuck waiting for each
-%% other during a full cluster restart. To make things realistic, this
+%% other during a full cluster parallel restart. To make things realistic, this
 %% testcase creates a wait chain of tables, where creation of one
 %% table depends on waiting for another.
-t_full_cluster_restart(_) ->
+t_full_cluster_parallel_restart(_) ->
     Cluster = mria_ct:cluster([core, core, core], mria_mnesia_test_util:common_env()),
     ?check_trace(
        #{timetrap => 30_000},
@@ -1253,8 +1253,41 @@ t_full_cluster_restart(_) ->
            %% Restart nodes simultaneously:
            ?tp(notice, test_restart_nodes, #{}),
            [ok = slave:stop(N) || N <- Nodes],
-           [mria_ct:start_slave(mria, CN) || CN <- Cluster],
+           Me = self(),
+           [spawn_link(fun() -> mria_ct:start_slave(mria, CN), Me ! {slave_up, CN},timer:sleep(60000) end) || CN <- Cluster],
+           %% Waiting for all slaves are started.
+           _ = [ ok  || CN <- Cluster, receive {slave_up, CN} -> true end],
            %% Restart the chain:
+           OK = erpc:multicall(Nodes, ?MODULE, full_restart_load_chain, [], infinity),
+           ok
+       after
+           ok = mria_ct:teardown_cluster(Cluster)
+       end,
+       []).
+
+%% This testcase verifies that nodes don't get stuck waiting for each
+%% other during a full cluster seq restart. To make things realistic, this
+%% testcase creates a wait chain of tables, where creation of one
+%% table depends on waiting for another.
+t_full_cluster_seq_restart(_) ->
+    Cluster = mria_ct:cluster([core, core, core], mria_mnesia_test_util:common_env()),
+    ?check_trace(
+       #{timetrap => 30_0000},
+       try
+           Nodes = [N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
+           OK = [{ok, ok}, {ok, ok}, {ok, ok}],
+           OK = erpc:multicall(Nodes, ?MODULE, full_restart_load_chain, [], infinity),
+           %% Write some data:
+           ok = ?ON(N1, mria:dirty_write(tab1, {tab1, foo, bar})),
+           ok = ?ON(N2, mria:dirty_write(tab2, {tab2, foo, bar})),
+           ok = ?ON(N3, mria:dirty_write(tab3, {tab3, foo, bar})),
+           %% Stop nodes in order:
+           %% Add 200ms delay in between to give time for mnesia DECISION table dump
+           %% so that DOWN nodes are known when they start.
+           ?tp(notice, test_restart_nodes, #{}),
+           [ok = slave:stop(N) || N <- Nodes, ok == timer:sleep(200)],
+           %% Start node in reversed order.
+           [mria_ct:start_slave(mria, CN) || CN <- lists:reverse(Cluster)],
            OK = erpc:multicall(Nodes, ?MODULE, full_restart_load_chain, [], infinity),
            ok
        after


### PR DESCRIPTION
for https://github.com/emqx/otp/pull/89

when running the test with above OTP fix, the old testcase `t_full_cluster_restart` is failed because the nodes are started in sequence,  and the first started node are blocking for `mria_schema` table (ram_copies table) sync from 'better' copies from other nodes.

Trouble tabes are:
```
[{test_tab,ram_only},
  {test_bag,ram_only},
  {mria_helper_tab,ram_only},
  {mria_schema,ram_only}]
```

```
(n1@127.0.0.1)1> erlang:process_info(whereis(mria_schema),current_stacktrace).
{current_stacktrace,[{mnesia_controller,do_wait_for_tables,
                                        2,
                                        [{file,"mnesia_controller.erl"},{line,239}]},
                     {mria_mnesia,wait_for_tables,1,
                                  [{file,"/home/ubuntu/repo/mria/src/mria_mnesia.erl"},
                                   {line,267}]},
                     {mria_schema,bootstrap,0,
                                  [{file,"/home/ubuntu/repo/mria/src/mria_schema.erl"},
                                   {line,332}]},
                     {mria_schema,init,1,
                                  [{file,"/home/ubuntu/repo/mria/src/mria_schema.erl"},
                                   {line,186}]},
                     {gen_server,init_it,2,[{file,"gen_server.erl"},{line,2229}]},
                     {gen_server,init_it,6,[{file,"gen_server.erl"},{line,2184}]},
                     {proc_lib,init_p_do_apply,3,
                               [{file,"proc_lib.erl"},{line,329}]}]}
                               
                               
(n1@127.0.0.1)2> rp(mnesia:table_info(mria_schema, all)).
[{access_mode,read_write},
 {active_replicas,[]},
 {all_nodes,['n3@127.0.0.1','n2@127.0.0.1','n1@127.0.0.1']},
 {arity,5},
 {attributes,[mnesia_table,shard,storage,config]},
 {checkpoints,[]},
 {commit_work,[]},
 {cookie,{{1776429955260534429,-576460752303422751,1},
          'n1@127.0.0.1'}},
 {cstruct,{cstruct,mria_schema,ordered_set,
                   ['n3@127.0.0.1','n2@127.0.0.1','n1@127.0.0.1'],
                   [],[],[],0,read_write,false,[],[],false,mria_schema,
                   [mnesia_table,shard,storage,config],
                   [],[],[],
                   {{1776429955260534429,-576460752303422751,1},'n1@127.0.0.1'},
                   {{4,0},{'n3@127.0.0.1',{1776,429955,970863}}}}},
 {disc_copies,[]},
 {disc_only_copies,[]},
 {external_copies,[]},
 {frag_properties,[]},
 {index,[]},
 {index_info,{index,ordered_set,[]}},
 {load_by_force,false},
 {load_node,unknown},
 {load_order,0},
 {load_reason,unknown},
 {local_content,false},
 {majority,false},
 {master_nodes,[]},
 {memory,undefined},
 {null_copies,[]},
 {ram_copies,['n3@127.0.0.1','n2@127.0.0.1','n1@127.0.0.1']},
 {record_name,mria_schema},
 {record_validation,{mria_schema,5,ordered_set}},
 {rocksdb_copies,[]},
 {size,undefined},
 {snmp,[]},
 {storage_properties,[]},
 {storage_type,ram_copies},
 {subscribers,[]},
 {type,ordered_set},
 {user_properties,[]},
 {version,{{4,0},{'n3@127.0.0.1',{1776,429955,970863}}}},
 {where_to_commit,[]},
 {where_to_read,nowhere},
 {where_to_write,[]},
 {wild_pattern,{mria_schema,'_','_','_','_'}}]

```

