### PR TITLE
feat(mria): Remove mnesia compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ This allows to improve write throughput of the cluster without sacrificing read 
 
 ![](doc/logo.jpg "Mriya logo")
 
-## Modes of operation
-
-Mria works in two modes:
-
-1. As a thin wrapper for Mnesia
-1. In a so called `RLOG` mode (Replication LOG)
-
-RLOG feature is disabled by default.
-It can be enabled by setting `mria.db_backend` application environment variable to `rlog`.
-
 ## Node roles
 
 When RLOG is enabled, each node assumes one of the two roles: `core` or `replicant`.

--- a/src/mria_app.erl
+++ b/src/mria_app.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 %%================================================================================
 
 start(_Type, _Args) ->
-    ?tp(notice, "Starting mria", #{}),
+    ?tp(notice, "Starting mria", #{env => application:get_all_env(mria)}),
     mria_config:load_config(),
     mria_rlog:init(),
     ?tp(notice, "Starting mnesia", #{}),

--- a/src/mria_config.erl
+++ b/src/mria_config.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -109,7 +109,8 @@ shard_config(Shard) ->
 
 -spec backend() -> mria:backend().
 backend() ->
-    persistent_term:get(?mria(db_backend), mnesia).
+    %% Note: always `rlog' since `db_backend' is not set.
+    persistent_term:get(?mria(db_backend), rlog).
 
 -spec role() -> mria_rlog:role().
 role() ->
@@ -163,7 +164,6 @@ load_config() ->
     copy_from_env(rlog_rpc_module),
     copy_from_env(core_rpc_retries),
     copy_from_env(core_rpc_cooldown),
-    copy_from_env(db_backend),
     copy_from_env(node_role),
     copy_from_env(strict_mode),
     copy_from_env(replay_batch_size),

--- a/src/mria_rlog_merged_manager.erl
+++ b/src/mria_rlog_merged_manager.erl
@@ -54,7 +54,7 @@ init([Shard]) ->
     S = #s{ shard = Shard
           , pg_ref = Ref
           },
-    {ok, S}.
+    {ok, manage_workers(S)}.
 
 handle_call(_Call, _From, S) ->
     {reply, {error, unknown_call}, S}.

--- a/test/mria_SUITE.erl
+++ b/test/mria_SUITE.erl
@@ -1066,9 +1066,9 @@ t_mnesia_post_commit_hook(_) ->
                ok
        end).
 
-t_replicant_receives_commits_from_pure_mnesia(_) ->
+t_replicant_receives_commits_from_remote_node(_) ->
     Cluster = mria_ct:cluster( [ core
-                               , {core, [{mria, db_backend, mnesia}]}
+                               , core
                                , replicant
                                , replicant
                                ]
@@ -1078,7 +1078,6 @@ t_replicant_receives_commits_from_pure_mnesia(_) ->
        #{timetrap => 30000},
        try
            Nodes = [_N1, N2, _N3, _N4] = mria_ct:start_cluster(mria, Cluster),
-           ?assertEqual({ok, mnesia}, erpc:call(N2, application, get_env, [mria, db_backend])),
            %% generate operations in the pure mnesia node
            %% 1. transaction
            ?assertEqual(

--- a/test/mria_autoheal_SUITE.erl
+++ b/test/mria_autoheal_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2021, 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/mria_lb_SUITE.erl
+++ b/test/mria_lb_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2019-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -115,26 +115,6 @@ t_probe(_Config) ->
                %% ?assertEqual([], ?of_kind("Different Mria version on the core node", Trace5)),
                ok
        end).
-
-t_probe_pure_mnesia(_Config) ->
-    Cluster = mria_ct:cluster( [ core
-                               , {core, [{mria, db_backend, mnesia}]}
-                               , replicant
-                               ]
-                             , mria_mnesia_test_util:common_env()
-                             ),
-    ?check_trace(
-       #{timetrap => 30000},
-       try
-           [N1, N2, N3] = mria_ct:start_cluster(mria, Cluster),
-           ?assert(erpc:call(N3, mria_rlog_server, probe, [N1, test_shard])),
-           %% should return false, since it's a pure mnesia node
-           ?assertNot(erpc:call(N3, mria_rlog_server, probe, [N2, test_shard])),
-           ok
-       after
-           mria_ct:teardown_cluster(Cluster)
-       end,
-       []).
 
 t_core_node_discovery(_Config) ->
     Cluster = mria_ct:cluster([core, replicant, core], mria_mnesia_test_util:common_env()),

--- a/test/mria_proper_mixed_cluster_suite_.erl
+++ b/test/mria_proper_mixed_cluster_suite_.erl
@@ -33,7 +33,7 @@ t_import_transactions_mixed_cluster(Config0) when is_list(Config0) ->
                          timeout  => 100000
                         }} | Config0],
     ClusterConfig = [ core
-                    , {core, [{mria, db_backend, mnesia}]}
+                    , core
                     , replicant
                     ],
     ?run_prop(Config, mria_proper_utils:prop(ClusterConfig, ?MODULE)).


### PR DESCRIPTION
This fix removes mnesia compatibility mode, because it is impossible to emulate merge table functionality without rlog.