### PR TITLE
chore(classy): Unify on_run_level hooks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
   {mnesia_rocksdb, {git, "https://github.com/emqx/mnesia_rocksdb", {tag, "0.1.17"}}},
   {optvar, {git, "https://github.com/emqx/optvar", {tag, "1.0.5"}}},
   {gproc, {git, "https://github.com/uwiger/gproc", {tag, "1.1.0"}}},
-  {classy, {git, "https://github.com/emqx/classy", {tag, "0.1.8"}}},
+  {classy, {git, "https://github.com/emqx/classy", {tag, "0.1.9"}}},
   {familiar, {git, "https://github.com/ieQu1/familiar", {tag, "0.1.4"}}}
  ]}.
 

--- a/src/mria_app.erl
+++ b/src/mria_app.erl
@@ -20,6 +20,8 @@
 
 -export([start/2, stop/1]).
 
+-export([ready/0]).
+
 %% Classy hooks
 -export([ on_run_level/2
         , on_node_init/0
@@ -57,6 +59,14 @@ start(_Type, _Args) ->
 stop(_) ->
     mria_config:erase_all_config(),
     ok.
+
+%%================================================================================
+%% Misc API
+%%================================================================================
+
+-spec ready() -> boolean().
+ready() ->
+    mria_rlog_sup:is_ready().
 
 %%================================================================================
 %% Classy hooks

--- a/src/mria_app.erl
+++ b/src/mria_app.erl
@@ -21,8 +21,7 @@
 -export([start/2, stop/1]).
 
 %% Classy hooks
--export([ on_run_level_high/2
-        , on_run_level_low/2
+-export([ on_run_level/2
         , on_node_init/0
         , on_create_cluster/2
         , pre_join/4
@@ -69,15 +68,12 @@ on_node_init() ->
     application:set_env(classy, to_cluster_sets, [core]),
     ok.
 
-on_run_level_high(stopped, single) ->
+on_run_level(stopped, single) ->
     {ok, _Apps} = application:ensure_all_started(mria),
     ok;
-on_run_level_high(_, _) ->
-    ok.
-
-on_run_level_low(single, stopped) ->
+on_run_level(single, stopped) ->
     mria:stop();
-on_run_level_low(_, _) ->
+on_run_level(_, _) ->
     ok.
 
 on_prep_stop(_Reason) ->
@@ -250,8 +246,7 @@ install_hooks(Prio) ->
     , classy:on_membership_change(fun ?MODULE:on_membership_change/4, Prio)
     , classy:on_node_classify(fun ?MODULE:on_node_classify/1, Prio)
       %% Run level:
-    , classy:run_level(fun ?MODULE:on_run_level_high/2, Prio)
-    , classy:run_level(fun ?MODULE:on_run_level_low/2, -Prio)
+    , classy:run_level(fun ?MODULE:on_run_level/2, Prio)
       %% Shutdown:
     , classy:on_prep_stop(fun ?MODULE:on_prep_stop/1, Prio)
     ].

--- a/src/mria_rlog_sup.erl
+++ b/src/mria_rlog_sup.erl
@@ -20,7 +20,7 @@
 
 -behaviour(supervisor).
 
--export([init/1, start_link/0]).
+-export([init/1, start_link/0, is_ready/0]).
 
 -define(SUPERVISOR, ?MODULE).
 
@@ -34,6 +34,10 @@
 start_link() ->
     Role = mria_rlog:role(),
     supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, Role).
+
+-spec is_ready() -> boolean().
+is_ready() ->
+    is_pid(whereis(?SUPERVISOR)).
 
 %%================================================================================
 %% supervisor callbacks

--- a/test/mria_join_fixture.erl
+++ b/test/mria_join_fixture.erl
@@ -13,7 +13,8 @@ init_per_node(Site, _Node, JoinTo, Acc) ->
             case is_peer(JoinTo, Site) of
                 false ->
                     ?assertEqual(ok, familiar:call(Site, classy, join_node, [JoinTo, join])),
-                    ?retry(100, 10, ?assertEqual(true, is_peer(JoinTo, Site)));
+                    ?retry(100, 100, ?assert(is_peer(JoinTo, Site))),
+                    ?retry(100, 100, ?assert(familiar:call(Site, mria_app, ready, [])));
                 true ->
                     ok
             end,


### PR DESCRIPTION
Update classy version. The changes include the ability to automatically reverse the order of `run_level` hook execution, so hi/low hooks are no longer needed.